### PR TITLE
Add /now page

### DIFF
--- a/src/components/AnimatedRoutes.tsx
+++ b/src/components/AnimatedRoutes.tsx
@@ -18,6 +18,7 @@ import Experience from "@/pages/Experience";
 import Contact from "@/pages/Contact";
 import Services from "@/pages/Services";
 import AboutThisWebsite from "@/pages/AboutThisWebsite";
+import Now from "@/pages/Now";
 import SimpleLayout from "@/layouts/SimpleLayout";
 import MainLayout from "@/layouts/MainLayout";
 import BlankLayout from "@/layouts/BlankLayout";
@@ -134,18 +135,28 @@ export const AnimatedRoutes = () => {
           } 
         />
         
-        <Route 
-          path="/services" 
+        <Route
+          path="/services"
           element={
             <MainLayout>
               {withTransition(Services)}
             </MainLayout>
-          } 
+          }
         />
-  
+
+        {/* now page */}
+        <Route
+          path="/now"
+          element={
+            <BlankLayout>
+              <Now />
+            </BlankLayout>
+          }
+        />
+
         {/* 這個網站是怎麼造出來的 */}
-        <Route 
-          path="/a" 
+        <Route
+          path="/a"
           element={
             <BlankLayout>
               <AboutThisWebsite />

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -85,19 +85,29 @@ const Index = () => {
                       className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold mb-3 sm:mb-4 md:mb-6"
                     >
                       <NameMorpher greeting={`${t.index.greeting}\u00A0`} />
-                      <Link to="/now" className="text-base ml-2 underline">
-                        now
-                      </Link>
                     </motion.h1>
                     
-                    <motion.p 
+                    <motion.p
                       variants={itemVariants}
                       initial="hidden"
                       animate="visible"
-                      className="text-foreground/70 leading-relaxed mb-4 sm:mb-5 md:mb-8 text-base sm:text-lg md:text-xl max-w-2xl md:max-w-3xl lg:max-w-4xl"
+                      className="text-foreground/70 leading-relaxed mb-2 sm:mb-3 md:mb-4 text-base sm:text-lg md:text-xl max-w-2xl md:max-w-3xl lg:max-w-4xl"
                     >
                       {t.index.description}
                     </motion.p>
+                    <motion.div
+                      variants={itemVariants}
+                      initial="hidden"
+                      animate="visible"
+                      className="mb-4 sm:mb-5 md:mb-8"
+                    >
+                      <Link
+                        to="/now"
+                        className="text-base text-primary underline-offset-4 hover:underline"
+                      >
+                        What I'm doing now →
+                      </Link>
+                    </motion.div>
 
                     <motion.div 
                       variants={itemVariants}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -78,13 +78,16 @@ const Index = () => {
               <div className="flex-1 flex flex-col justify-center items-start">
                 <div className="flex flex-col">
                   <div className="max-w-3xl md:max-w-4xl lg:max-w-5xl ml-0">
-                    <motion.h1 
+                    <motion.h1
                       variants={titleVariants}
                       initial="hidden"
                       animate="visible"
                       className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold mb-3 sm:mb-4 md:mb-6"
                     >
                       <NameMorpher greeting={`${t.index.greeting}\u00A0`} />
+                      <Link to="/now" className="text-base ml-2 underline">
+                        now
+                      </Link>
                     </motion.h1>
                     
                     <motion.p 

--- a/src/pages/Now.tsx
+++ b/src/pages/Now.tsx
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2025 Yanis Sebastian Zürcher
+ *
+ * This file is part of the project and is subject to the terms of the project's LICENSE (GNU GPL v3).
+ * Please refer to the LICENSE file in the project root for full licensing details.
+ *
+ * All rights reserved.
+ */
+
+import { Helmet } from "react-helmet-async";
+import { useNavigate } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+
+export default function Now() {
+  const navigate = useNavigate();
+
+  const goBack = () => navigate(-1);
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center px-6 py-12 bg-background text-foreground">
+      <Helmet>
+        <title>Now</title>
+        <meta name="robots" content="noindex, nofollow" />
+      </Helmet>
+
+      <div className="max-w-2xl w-full text-sm leading-relaxed space-y-6">
+        <h1 className="text-2xl font-bold mb-6 text-center">Now</h1>
+
+        <p>
+          Here's what I'm focused on at the moment. This page is inspired by the <a href="https://nownownow.com/about" className="underline" target="_blank" rel="noopener noreferrer">nownownow</a> movement.
+        </p>
+        <p>
+          I'm continuing my studies in computer science while building side projects and sharpening my skills.
+        </p>
+        <p>
+          Check back occasionally to see what I'm up to!
+        </p>
+
+        <Button variant="link" effect="underline" onClick={goBack}>go back?</Button>
+
+        <p className="text-xs text-center text-foreground/50 pt-8">
+          © {new Date().getFullYear()} Yanis Sebastian Zürcher
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Now.tsx
+++ b/src/pages/Now.tsx
@@ -10,38 +10,61 @@
 import { Helmet } from "react-helmet-async";
 import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
+import { motion, AnimatePresence } from "motion/react";
+import { containerVariants, itemVariants, titleVariants, usePageInit } from "@/utils/transitions";
 
 export default function Now() {
+  const isLoaded = usePageInit(50);
   const navigate = useNavigate();
 
   const goBack = () => navigate(-1);
 
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center px-6 py-12 bg-background text-foreground">
-      <Helmet>
-        <title>Now</title>
-        <meta name="robots" content="noindex, nofollow" />
-      </Helmet>
+    <AnimatePresence>
+      {isLoaded && (
+        <motion.div
+          initial="hidden"
+          animate="visible"
+          variants={containerVariants}
+          className="min-h-screen flex items-center justify-center px-6 py-12"
+        >
+          <Helmet>
+            <title>Now</title>
+            <meta name="robots" content="noindex, nofollow" />
+          </Helmet>
 
-      <div className="max-w-2xl w-full text-sm leading-relaxed space-y-6">
-        <h1 className="text-2xl font-bold mb-6 text-center">Now</h1>
+          <motion.div
+            variants={itemVariants}
+            className="max-w-2xl w-full text-sm leading-relaxed space-y-6 p-6 sm:p-8 rounded-xl border border-foreground/10 bg-foreground/5 backdrop-blur-md shadow-lg"
+          >
+            <motion.h1 variants={titleVariants} className="text-2xl font-bold mb-6 text-center">
+              Now
+            </motion.h1>
 
-        <p>
-          Here's what I'm focused on at the moment. This page is inspired by the <a href="https://nownownow.com/about" className="underline" target="_blank" rel="noopener noreferrer">nownownow</a> movement.
-        </p>
-        <p>
-          I'm continuing my studies in computer science while building side projects and sharpening my skills.
-        </p>
-        <p>
-          Check back occasionally to see what I'm up to!
-        </p>
+            <motion.p variants={itemVariants}>
+              Here's what I'm focused on at the moment. This page is inspired by the{' '}
+              <a href="https://nownownow.com/about" className="underline" target="_blank" rel="noopener noreferrer">
+                nownownow
+              </a>{' '}
+              movement.
+            </motion.p>
+            <motion.p variants={itemVariants}>
+              I'm continuing my studies in computer science while building side projects and sharpening my skills.
+            </motion.p>
+            <motion.p variants={itemVariants}>Check back occasionally to see what I'm up to!</motion.p>
 
-        <Button variant="link" effect="underline" onClick={goBack}>go back?</Button>
+            <motion.div variants={itemVariants} className="text-center">
+              <Button variant="link" effect="underline" onClick={goBack}>
+                go back?
+              </Button>
+            </motion.div>
 
-        <p className="text-xs text-center text-foreground/50 pt-8">
-          © {new Date().getFullYear()} Yanis Sebastian Zürcher
-        </p>
-      </div>
-    </div>
+            <motion.p variants={itemVariants} className="text-xs text-center text-foreground/50 pt-8">
+              © {new Date().getFullYear()} Yanis Sebastian Zürcher
+            </motion.p>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
   );
 }


### PR DESCRIPTION
## Summary
- create a standalone `Now` page
- register the page in the router
- link to `/now` from the homepage greeting

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840960fa63c832d81eeb293a6fc765a