### PR TITLE
Add Grafana skill

### DIFF
--- a/src/pages/Skills.tsx
+++ b/src/pages/Skills.tsx
@@ -18,6 +18,7 @@ import {
   SiGit, SiGithub, SiLinux, SiNginx, SiSpringboot, SiMongodb,
   SiJavascript, SiRedis, SiKubernetes,
   SiJenkins,
+  SiGrafana,
   SiVite,
   SiAntdesign,
   SiMysql,
@@ -75,9 +76,10 @@ const Skills = () => {
         { name: "Visual Studio Code", icon: BiLogoVisualStudio, level: 80},
         { name: "Docker", icon: SiDocker, level: 75 },
         { name: "Linux", icon: SiLinux, level: 72 },
-        { name: "Kubernetes", icon: SiKubernetes, level: 62 }
+        { name: "Kubernetes", icon: SiKubernetes, level: 62 },
+        { name: "Grafana", icon: SiGrafana, level: 60 }
       ]
-    }, 
+    },
     {
       title: "Other",
       skills: [


### PR DESCRIPTION
## Summary
- add Grafana icon import
- list Grafana with other Tools skills

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68421b5bb798832db9deb9c89878e6c2