### PR TITLE
Add ESLint to skills list

### DIFF
--- a/src/pages/Skills.tsx
+++ b/src/pages/Skills.tsx
@@ -30,6 +30,7 @@ import {
   SiKalilinux,
   SiZoom,
   SiOpensourceinitiative,
+  SiEslint,
 
 } from "react-icons/si";
 
@@ -76,6 +77,7 @@ const Skills = () => {
         { name: "Visual Studio Code", icon: BiLogoVisualStudio, level: 80},
         { name: "Docker", icon: SiDocker, level: 75 },
         { name: "Linux", icon: SiLinux, level: 72 },
+        { name: "ESLint", icon: SiEslint, level: 70 },
         { name: "Kubernetes", icon: SiKubernetes, level: 62 },
         { name: "Grafana", icon: SiGrafana, level: 60 }
       ]


### PR DESCRIPTION
## Summary
- include ESLint icon in skills imports
- list ESLint in the Tools section with a skill level

## Testing
- `npm ci`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684229d23a18832d8d2c5e70d3039001