### PR TITLE
refactor: redesign 404 page

### DIFF
--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * Copyright (c) 2025 Yanis Sebastian Zürcher
  *
  * This file is part of a proprietary software project.
@@ -6,108 +6,36 @@
  * Refer to LICENSE for details or contact yanis.sebastian.zuercher@gmail.com for permissions.
  */
 
-import { useEffect, useState } from "react";
 import { Helmet } from "react-helmet-async";
 import { Button } from "@/components/ui/button";
 import { useLanguage } from "@/lib/language-provider";
 import { translations, type Translation } from "@/lib/translations";
-import { useLocation } from "react-router-dom";
-
-const TYPING_SPEED = 50;
-const RESPONSE_DELAY = 600;
-const INITIAL_DELAY = 1500;
+import { Link } from "react-router-dom";
+import { Ghost } from "lucide-react";
 
 const NotFound = () => {
-  const location = useLocation();
   const { language } = useLanguage();
   const t = translations[language] as Translation;
-  const ROOT_PROMPT = "root@~/dev/null$ ";
-  const PROMPT = `curl https://sola.ysz.life${location.pathname}`;
-  const RESPONSE_LINES = [
-    "",
-    "HTTP/1.1 404 Not Found",
-    "{",
-    `  "error": "Resource not found"`,
-    "}",
-  ];
-
-  const [typedPrompt, setTypedPrompt] = useState("");
-  const [typedResponse, setTypedResponse] = useState<string[]>([]);
-  const [lineIndex, setLineIndex] = useState(0);
-  const [isInitialDelay, setIsInitialDelay] = useState(true);
-
-  useEffect(() => {
-    if (isInitialDelay) {
-      const initialTimeout = setTimeout(() => {
-        setIsInitialDelay(false);
-      }, INITIAL_DELAY);
-      return () => clearTimeout(initialTimeout);
-    }
-
-    if (typedPrompt.length < PROMPT.length) {
-      const timeout = setTimeout(() => {
-        setTypedPrompt((prev) => prev + PROMPT[prev.length]);
-      }, TYPING_SPEED);
-      return () => clearTimeout(timeout);
-    }
-
-    const responseTimeout = setTimeout(() => {
-      typeResponseLine(0);
-    }, RESPONSE_DELAY);
-
-    return () => clearTimeout(responseTimeout);
-  }, [typedPrompt, isInitialDelay]);
-
-  const typeResponseLine = (index: number) => {
-    if (index < RESPONSE_LINES.length) {
-      setTimeout(() => {
-        setTypedResponse((prev) => [...prev, RESPONSE_LINES[index]]);
-        typeResponseLine(index + 1);
-      }, 80);
-    }
-  };
 
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center px-4 sm:px-6 bg-background text-foreground">
+    <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-background to-muted p-4 text-center text-foreground">
       <Helmet>
         <title>{t.seo.notFound.title}</title>
         <meta name="description" content={t.seo.notFound.description} />
         <meta name="robots" content="noindex, nofollow" />
       </Helmet>
 
-      <div className="w-full max-w-2xl bg-muted border border-border rounded-xl shadow-2xl overflow-hidden">
-        {/* Window bar */}
-        <div className="flex items-center gap-2 px-4 py-2 border-b border-border bg-muted/60 backdrop-blur-md">
-          <span className="h-3 w-3 rounded-full bg-destructive shadow-sm" />
-          <span className="h-3 w-3 rounded-full bg-yellow-400 shadow-sm" />
-          <span className="h-3 w-3 rounded-full bg-primary shadow-sm" />
-        </div>
-
-        {/* Terminal */}
-        <pre className="p-6 font-mono text-sm sm:text-base leading-relaxed whitespace-pre-wrap text-muted-foreground">
-          {ROOT_PROMPT}
-          {typedPrompt}
-          {(isInitialDelay || typedPrompt.length < PROMPT.length) && (
-            <span className="inline-block animate-pulse w-2">▮</span>
-          )}
-          {typedResponse.length > 0 &&
-            typedResponse.map((line, idx) => (
-              <div key={idx} className="opacity-90">
-                {line}
-              </div>
-            ))}
-        </pre>
-      </div>
-
-      <Button
-        asChild
-        variant="outline"
-        className="mt-6 text-sm border-border hover:bg-muted/70 transition-colors"
-      >
-        <a href="/">{t.notFound.backHome}</a>
+      <Ghost className="h-24 w-24 text-primary animate-bounce" />
+      <h1 className="mt-6 text-5xl sm:text-6xl font-bold tracking-tight">404</h1>
+      <p className="mt-4 text-muted-foreground max-w-md">
+        {t.seo.notFound.description}
+      </p>
+      <Button asChild className="mt-8">
+        <Link to="/">{t.notFound.backHome}</Link>
       </Button>
     </div>
   );
 };
 
 export default NotFound;
+


### PR DESCRIPTION
## Summary
- replace terminal-style 404 page with minimalist bouncing-ghost design

## Testing
- `npm run lint` *(fails: Unexpected any, irregular whitespace, no-unknown-property, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a21df734832d9783aceed62204f1