### PR TITLE
Revamp service pricing presentation

### DIFF
--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -399,70 +399,66 @@ export const translations = {
     },
     services: {
       title: "Services",
-      subtitle: "Comprehensive software development services tailored to your needs.",
+      subtitle: "Focused development support for shipping faster.",
       backHome: "Back home",
-      pricing: "Listed rates are starting points—each proposal is tailored to match your project's scope and priorities.",
+      pricing: "Choose the engagement that fits best—these rates are typical starting points and final estimates follow discovery.",
       startingFrom: "Starting from",
       getStarted: "Get Started",
       heroHighlights: [
-        "Discovery-focused kickoff sessions",
-        "Milestone-based delivery cadence",
-        "Maintainable, well-documented code",
+        "Lightweight scopes, no surprises",
+        "Weekly progress check-ins",
       ],
       services: {
         fullstack: {
           title: "Full Stack Development",
-          description: "End-to-end web application development using modern technologies.",
+          description: "Plan, build, and evolve complete web products end to end.",
           features: [
-            "Responsive web applications",
-            "RESTful API development",
-            "Database design and implementation",
-            "Performance optimization"
+            "Architecture & scope definition",
+            "Frontend and backend implementation",
+            "Launch support and handover",
           ],
-          badge: "",
-          price: "CHF 3,200"
+          badge: "All-in-one",
+          price: "CHF 3,200+"
         },
         frontend: {
           title: "Frontend Development",
-          description: "Creating beautiful, responsive, and user-friendly interfaces.",
+          description: "Craft responsive, accessible, and on-brand interfaces.",
           features: [
-            "React development",
-            "UI/UX implementation",
-            "Animation and interactivity",
-            "Mobile-first design"
+            "Responsive React implementations",
+            "Design system rollouts",
+            "Interaction polish & accessibility",
           ],
-          badge: "Most Popular",
-          price: "CHF 1,600"
+          badge: "Popular",
+          price: "CHF 1,600+"
         },
         backend: {
           title: "Backend Development",
-          description: "Robust and scalable server-side solutions.",
+          description: "Design dependable services that scale with your product.",
           features: [
-            "API architecture",
-            "Database management",
-            "Server optimization",
-            "Security implementation"
+            "API and service architecture",
+            "Database modelling & migrations",
+            "Deployment and observability setup",
           ],
           badge: "",
-          price: "CHF 1,900"
+          price: "CHF 1,900+"
         },
         consulting: {
           title: "Technical Consulting",
-          description: "Expert guidance for your technical decisions.",
+          description: "Get clarity on architecture, stack choices, and next steps.",
           features: [
-            "Architecture planning",
-            "Technology stack selection",
-            "Performance auditing",
-            "Security assessment"
+            "Architecture and stack reviews",
+            "Performance & security audits",
+            "Pairing sessions with your team",
           ],
           badge: "",
           price: "CHF 120 / hour"
         }
       },
       customRequirements: {
-        title: "Custom Requirements?",
-        description: "Have a specific project in mind? I'm here to help turn your vision into reality. Let's discuss your requirements and create a tailored solution for your needs.",
-        button: "Get in touch"
+        title: "Need something custom?",
+        description: "If your scope doesn’t fit neatly into these packages, let’s outline a tailored collaboration.",
+        button: "Start a conversation",
+        note: "Share a quick overview and I'll respond within one business day."
       }
     },
   },
@@ -856,70 +852,66 @@ export const translations = {
     },
     services: {
       title: "Dienstleistungen",
-      subtitle: "Umfassende Softwareentwicklungsdienste, angepasst an Ihre Bedürfnisse.",
+      subtitle: "Fokussierte Entwicklungsleistungen für schnelle Ergebnisse.",
       backHome: "Zurück",
-      pricing: "Die aufgeführten Preise dienen als Ausgangspunkt – das finale Angebot richtet sich nach Ihrem Projektumfang und Ihren Prioritäten.",
+      pricing: "Wählen Sie das passende Angebot – die Beträge sind typische Einstiegspreise, das finale Angebot entsteht nach dem Kennenlernen.",
       startingFrom: "Ab",
       getStarted: "Loslegen",
       heroHighlights: [
-        "Discovery-orientierte Kick-off-Workshops",
-        "Lieferung in klaren Meilensteinen",
-        "Wartbarer, sauber dokumentierter Code",
+        "Klare Projektumfänge ohne Überraschungen",
+        "Wöchentliche Status-Updates",
       ],
       services: {
         fullstack: {
           title: "Full-Stack-Entwicklung",
-          description: "Ganzheitliche Webentwicklung mit modernen Technologien.",
+          description: "Konzipiere, entwickle und erweitere komplette Webprodukte aus einer Hand.",
           features: [
-            "Responsive Webanwendungen",
-            "RESTful API-Entwicklung",
-            "Datenbankdesign und -implementierung",
-            "Leistungsoptimierung"
+            "Architektur- und Scope-Definition",
+            "Frontend- und Backend-Umsetzung",
+            "Begleitung bis zum Launch",
           ],
-          badge: "",
-          price: "CHF 3'200"
+          badge: "Rundumpaket",
+          price: "CHF 3'200+"
         },
         frontend: {
           title: "Frontend-Entwicklung",
-          description: "Erstellung schöner und benutzerfreundlicher Oberflächen.",
+          description: "Baue reaktionsschnelle, zugängliche und markenkonforme Interfaces.",
           features: [
-            "React development",
-            "UI/UX-Implementierung",
-            "Animation und Interaktivität",
-            "Mobile-First-Design"
+            "Responsive React-Implementierungen",
+            "Design-System-Rollouts",
+            "Interaktions-Feinschliff & Barrierefreiheit",
           ],
-          badge: "Meistgebucht",
-          price: "CHF 1'600"
+          badge: "Beliebt",
+          price: "CHF 1'600+"
         },
         backend: {
           title: "Backend-Entwicklung",
-          description: "Robuste und skalierbare Server-Lösungen.",
+          description: "Entwirf belastbare Services, die mit deinem Produkt skalieren.",
           features: [
-            "API-Architektur",
-            "Datenbankverwaltung",
-            "Server-Optimierung",
-            "Sicherheitsimplementierung"
+            "API- und Service-Architektur",
+            "Datenbankmodellierung & Migrationen",
+            "Deployment und Observability",
           ],
           badge: "",
-          price: "CHF 1'900"
+          price: "CHF 1'900+"
         },
         consulting: {
           title: "Technische Beratung",
-          description: "Expertenhilfe bei technischen Entscheidungen.",
+          description: "Erhalte Klarheit bei Architektur, Stack-Auswahl und nächsten Schritten.",
           features: [
-            "Architekturplanung",
-            "Technologie-Stack-Auswahl",
-            "Performance-Auditing",
-            "Sicherheitsbewertung"
+            "Architektur- & Stack-Reviews",
+            "Performance- und Security-Audits",
+            "Gemeinsame Sessions mit deinem Team",
           ],
           badge: "",
           price: "CHF 120 / Stunde"
         }
       },
       customRequirements: {
-        title: "Spezielle Anforderungen?",
-        description: "Haben Sie ein bestimmtes Projekt im Sinn? Ich helfe Ihnen dabei, Ihre Vision Wirklichkeit werden zu lassen. Lassen Sie uns Ihre Anforderungen besprechen und eine passende Lösung entwickeln.",
-        button: "Kontaktieren Sie mich"
+        title: "Individuelle Anforderungen?",
+        description: "Ihr Vorhaben passt nicht in diese Pakete? Lassen Sie uns eine maßgeschneiderte Zusammenarbeit definieren.",
+        button: "Gespräch starten",
+        note: "Schicken Sie mir eine kurze Zusammenfassung – ich melde mich innerhalb eines Werktags."
       }
     },
   },
@@ -1313,70 +1305,66 @@ export const translations = {
     },
     services: {
       title: "Servicios",
-      subtitle: "Servicios integrales de desarrollo de software adaptados a sus necesidades, entregados con experiencia y precisión.",
+      subtitle: "Soporte de desarrollo enfocado para lanzar más rápido.",
       backHome: "Regresar",
-      pricing: "Las tarifas indicadas son un punto de partida; la propuesta final se ajusta al alcance y prioridades de su proyecto.",
+      pricing: "Elige el servicio que mejor encaje — estas tarifas son precios iniciales habituales y el presupuesto final llega tras la fase de discovery.",
       startingFrom: "Desde",
       getStarted: "Comenzar",
       heroHighlights: [
-        "Sesiones de inicio centradas en discovery",
-        "Entrega con cadencia basada en hitos",
-        "Código mantenible y bien documentado",
+        "Alcances claros sin sorpresas",
+        "Revisiones de avance semanales",
       ],
       services: {
         fullstack: {
           title: "Desarrollo Full Stack",
-          description: "Desarrollo integral de aplicaciones web utilizando tecnologías modernas como React, Spring Boot y MongoDB.",
+          description: "Planificamos, construimos y evolucionamos productos web completos de principio a fin.",
           features: [
-            "Aplicaciones web responsivas",
-            "Desarrollo de API RESTful",
-            "Diseño e implementación de bases de datos",
-            "Optimización de rendimiento"
+            "Definición de arquitectura y alcance",
+            "Implementación frontend y backend",
+            "Acompañamiento en lanzamiento y traspaso",
           ],
-          badge: "",
-          price: "CHF 3,200"
+          badge: "Todo en uno",
+          price: "CHF 3,200+"
         },
         frontend: {
           title: "Desarrollo Frontend",
-          description: "Creación de interfaces atractivas, responsivas y fáciles de usar con marcos y sistemas de diseño modernos.",
+          description: "Diseñamos interfaces accesibles, responsivas y alineadas con tu marca.",
           features: [
-            "Desarrollo con React",
-            "Implementación de UI/UX",
-            "Animación e interactividad",
-            "Diseño mobile-first"
+            "Implementaciones React responsivas",
+            "Despliegue de sistemas de diseño",
+            "Pulido de interacciones y accesibilidad",
           ],
-          badge: "El más solicitado",
-          price: "CHF 1,600"
+          badge: "Popular",
+          price: "CHF 1,600+"
         },
         backend: {
           title: "Desarrollo Backend",
-          description: "Soluciones del lado del servidor robustas y escalables.",
+          description: "Diseñamos servicios confiables que escalan con tu producto.",
           features: [
-            "Arquitectura de API",
-            "Administración de bases de datos",
-            "Optimización de servidores",
-            "Implementación de seguridad"
+            "Arquitectura de APIs y servicios",
+            "Modelado y migraciones de bases de datos",
+            "Configuración de despliegue y observabilidad",
           ],
           badge: "",
-          price: "CHF 1,900"
+          price: "CHF 1,900+"
         },
         consulting: {
           title: "Consultoría Técnica",
-          description: "Orientación experta para sus decisiones técnicas.",
+          description: "Obtén claridad sobre arquitectura, stack y próximos pasos.",
           features: [
-            "Planificación de arquitectura",
-            "Selección de pila tecnológica",
-            "Auditoría de rendimiento",
-            "Evaluación de seguridad"
+            "Revisiones de arquitectura y stack",
+            "Auditorías de rendimiento y seguridad",
+            "Sesiones de acompañamiento con tu equipo",
           ],
           badge: "",
           price: "CHF 120 / hora"
         }
       },
       customRequirements: {
-        title: "¿Tienes requisitos personalizados?",
-        description: "¿Tienes un proyecto específico en mente? Te puedo ayudar a hacer tu visión realidad. Hagamos una reunión para discutir tus requisitos y crear una solución personalizada para tus necesidades.",
-        button: "Contáctame"
+        title: "¿Necesitas algo a medida?",
+        description: "Si tu proyecto no encaja en estos paquetes, definamos juntos una colaboración personalizada.",
+        button: "Iniciar conversación",
+        note: "Compárteme un resumen breve y te responderé en un día hábil."
       }
     }
   },
@@ -1771,70 +1759,66 @@ export const translations = {
     },
     services: {
       title: "サービス",
-      subtitle: "お客様のニーズに合わせた包括的なソフトウェア開発サービス。",
+      subtitle: "スピーディーなリリースを支える、集中型の開発サポート。",
       backHome: "ホームに戻る",
-      pricing: "掲載している料金は目安です。最終的なお見積もりはプロジェクトの内容と優先度に合わせて調整いたします。",
+      pricing: "プロジェクトに最適なプランをお選びください。表示料金は目安で、詳細なお見積もりはヒアリング後にご提示します。",
       startingFrom: "開始料金",
       getStarted: "今すぐ始める",
       heroHighlights: [
-        "ディスカバリー重視のキックオフセッション",
-        "明確なマイルストーンで進むデリバリー",
-        "保守しやすく文書化されたコード",
+        "驚きのない明確なスコープ",
+        "週次の進捗チェックイン",
       ],
       services: {
         fullstack: {
           title: "フルスタック開発",
-          description: "最新技術を使用したエンドツーエンドのWeb開発。",
+          description: "構想から運用まで、一貫してWebプロダクトを並走開発します。",
           features: [
-            "レスポンシブWebアプリケーション",
-            "RESTful API開発",
-            "データベース設計と実装",
-            "パフォーマンス最適化"
+            "アーキテクチャとスコープ設計",
+            "フロント・バックエンド実装",
+            "ローンチ支援と引き継ぎ",
           ],
-          badge: "",
-          price: "CHF 3,200"
+          badge: "ワンストップ",
+          price: "CHF 3,200+"
         },
         frontend: {
           title: "フロントエンド開発",
-          description: "美しく使いやすいインターフェースの作成。",
+          description: "ブランドに寄り添った、アクセシブルで反応の良いUIを構築します。",
           features: [
-            "React開発",
-            "UI/UX実装",
-            "アニメーションと対話",
-            "モバイルファースト設計"
+            "レスポンシブなReact実装",
+            "デザインシステム導入",
+            "インタラクションとアクセシビリティ調整",
           ],
-          badge: "一番人気",
-          price: "CHF 1,600"
+          badge: "人気",
+          price: "CHF 1,600+"
         },
         backend: {
           title: "バックエンド開発",
-          description: "堅牢でスケーラブルなサーバーサイドソリューション。",
+          description: "プロダクトの成長に合わせてスケールする堅牢なサービスを設計します。",
           features: [
-            "API設計",
-            "データベース管理",
-            "サーバー最適化",
-            "セキュリティ実装"
+            "API・サービスアーキテクチャ",
+            "データベース設計と移行",
+            "デプロイと可観測性の整備",
           ],
           badge: "",
-          price: "CHF 1,900"
+          price: "CHF 1,900+"
         },
         consulting: {
           title: "技術コンサルティング",
-          description: "技術的な意思決定のための専門家によるガイダンス。",
+          description: "アーキテクチャや技術選定、次の一手を明確にします。",
           features: [
-            "アーキテクチャ計画",
-            "技術スタックの選定",
-            "パフォーマンス監査",
-            "セキュリティ評価"
+            "アーキテクチャ／スタックレビュー",
+            "パフォーマンス＆セキュリティ診断",
+            "チームとの伴走セッション",
           ],
           badge: "",
           price: "CHF 120 / 時間"
         }
       },
       customRequirements: {
-        title: "カスタム要件をお持ちですか？",
-        description: "具体的なプロジェクトをお考えですか？あなたのビジョンを実現するお手伝いをさせていただきます。ご要件についてご相談させていただき、ニーズに合わせたソリューションを作成いたしましょう。",
-        button: "お問い合わせ"
+        title: "オーダーメイドが必要ですか？",
+        description: "既存プランに当てはまらない内容もお気軽にご相談ください。最適な進め方をご提案します。",
+        button: "相談してみる",
+        note: "概要をお送りいただければ、1営業日以内に折り返します。"
       }
     }
   },
@@ -2228,70 +2212,66 @@ export const translations = {
     },
     services: {
       title: "服务",
-      subtitle: "根据您的需求定制的全面软件开发服务。",
+      subtitle: "聚焦高效交付的轻量化开发服务。",
       backHome: "返回首页",
-      pricing: "列出的费用仅作起点，最终报价将根据您的项目范围与优先级量身定制。",
+      pricing: "选择最适合的合作方式——以下金额为常见起步价，最终报价将在需求沟通后确认。",
       startingFrom: "起价",
       getStarted: "开始",
       heroHighlights: [
-        "以探索为核心的启动会",
-        "基于清晰里程碑的交付节奏",
-        "注重可维护性的完善文档代码",
+        "范围清晰、过程透明",
+        "每周进度同步",
       ],
       services: {
         fullstack: {
           title: "全栈开发",
-          description: "使用现代技术进行端到端的Web开发。",
+          description: "从规划到上线，全程伴随构建完整的 Web 产品。",
           features: [
-            "响应式Web应用",
-            "RESTful API开发",
-            "数据库设计和实现",
-            "性能优化"
+            "架构与范围规划",
+            "前后端一体化实现",
+            "上线支持与交付交接",
           ],
-          badge: "",
-          price: "CHF 3,200"
+          badge: "一站式",
+          price: "CHF 3,200+"
         },
         frontend: {
           title: "前端开发",
-          description: "创建美观、响应式和用户友好的界面。",
+          description: "打造符合品牌的无障碍、响应式界面体验。",
           features: [
-            "React开发",
-            "UI/UX实现",
-            "动画和交互",
-            "移动优先设计"
+            "响应式 React 实现",
+            "设计系统落地",
+            "交互与无障碍优化",
           ],
-          badge: "最受欢迎",
-          price: "CHF 1,600"
+          badge: "热门",
+          price: "CHF 1,600+"
         },
         backend: {
           title: "后端开发",
-          description: "强大且可扩展的服务器端解决方案。",
+          description: "设计可随业务扩展的稳定服务与数据层。",
           features: [
-            "API设计",
-            "数据库管理",
-            "服务器优化",
-            "安全实现"
+            "API 与服务架构设计",
+            "数据库建模与迁移",
+            "部署与可观测性配置",
           ],
           badge: "",
-          price: "CHF 1,900"
+          price: "CHF 1,900+"
         },
         consulting: {
           title: "技术咨询",
-          description: "为您的技术决策提供专业指导。",
+          description: "为架构、技术选型与下一步行动提供清晰建议。",
           features: [
-            "架构规划",
-            "技术栈选择",
-            "性能审计",
-            "安全评估"
+            "架构与技术栈评审",
+            "性能与安全诊断",
+            "团队协作辅导",
           ],
           badge: "",
           price: "CHF 120 / 小时"
         }
       },
       customRequirements: {
-        title: "有特定需求？",
-        description: "有特定项目想法？我可以帮助您实现愿景。让我们讨论您的需求，为您创建量身定制的解决方案。",
-        button: "联系我"
+        title: "需要定制方案？",
+        description: "如果这些套餐无法覆盖您的需求，我们可以共同规划合适的合作方式。",
+        button: "发起交流",
+        note: "请先简单介绍项目背景，我会在1个工作日内回复。"
       }
     }
   } 

--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -404,6 +404,11 @@ export const translations = {
       pricing: "Listed rates are starting points—each proposal is tailored to match your project's scope and priorities.",
       startingFrom: "Starting from",
       getStarted: "Get Started",
+      heroHighlights: [
+        "Discovery-focused kickoff sessions",
+        "Milestone-based delivery cadence",
+        "Maintainable, well-documented code",
+      ],
       services: {
         fullstack: {
           title: "Full Stack Development",
@@ -414,6 +419,7 @@ export const translations = {
             "Database design and implementation",
             "Performance optimization"
           ],
+          badge: "",
           price: "CHF 3,200"
         },
         frontend: {
@@ -425,6 +431,7 @@ export const translations = {
             "Animation and interactivity",
             "Mobile-first design"
           ],
+          badge: "Most Popular",
           price: "CHF 1,600"
         },
         backend: {
@@ -436,6 +443,7 @@ export const translations = {
             "Server optimization",
             "Security implementation"
           ],
+          badge: "",
           price: "CHF 1,900"
         },
         consulting: {
@@ -447,6 +455,7 @@ export const translations = {
             "Performance auditing",
             "Security assessment"
           ],
+          badge: "",
           price: "CHF 120 / hour"
         }
       },
@@ -852,6 +861,11 @@ export const translations = {
       pricing: "Die aufgeführten Preise dienen als Ausgangspunkt – das finale Angebot richtet sich nach Ihrem Projektumfang und Ihren Prioritäten.",
       startingFrom: "Ab",
       getStarted: "Loslegen",
+      heroHighlights: [
+        "Discovery-orientierte Kick-off-Workshops",
+        "Lieferung in klaren Meilensteinen",
+        "Wartbarer, sauber dokumentierter Code",
+      ],
       services: {
         fullstack: {
           title: "Full-Stack-Entwicklung",
@@ -862,6 +876,7 @@ export const translations = {
             "Datenbankdesign und -implementierung",
             "Leistungsoptimierung"
           ],
+          badge: "",
           price: "CHF 3'200"
         },
         frontend: {
@@ -873,6 +888,7 @@ export const translations = {
             "Animation und Interaktivität",
             "Mobile-First-Design"
           ],
+          badge: "Meistgebucht",
           price: "CHF 1'600"
         },
         backend: {
@@ -884,6 +900,7 @@ export const translations = {
             "Server-Optimierung",
             "Sicherheitsimplementierung"
           ],
+          badge: "",
           price: "CHF 1'900"
         },
         consulting: {
@@ -895,6 +912,7 @@ export const translations = {
             "Performance-Auditing",
             "Sicherheitsbewertung"
           ],
+          badge: "",
           price: "CHF 120 / Stunde"
         }
       },
@@ -1300,6 +1318,11 @@ export const translations = {
       pricing: "Las tarifas indicadas son un punto de partida; la propuesta final se ajusta al alcance y prioridades de su proyecto.",
       startingFrom: "Desde",
       getStarted: "Comenzar",
+      heroHighlights: [
+        "Sesiones de inicio centradas en discovery",
+        "Entrega con cadencia basada en hitos",
+        "Código mantenible y bien documentado",
+      ],
       services: {
         fullstack: {
           title: "Desarrollo Full Stack",
@@ -1310,6 +1333,7 @@ export const translations = {
             "Diseño e implementación de bases de datos",
             "Optimización de rendimiento"
           ],
+          badge: "",
           price: "CHF 3,200"
         },
         frontend: {
@@ -1321,6 +1345,7 @@ export const translations = {
             "Animación e interactividad",
             "Diseño mobile-first"
           ],
+          badge: "El más solicitado",
           price: "CHF 1,600"
         },
         backend: {
@@ -1332,6 +1357,7 @@ export const translations = {
             "Optimización de servidores",
             "Implementación de seguridad"
           ],
+          badge: "",
           price: "CHF 1,900"
         },
         consulting: {
@@ -1343,6 +1369,7 @@ export const translations = {
             "Auditoría de rendimiento",
             "Evaluación de seguridad"
           ],
+          badge: "",
           price: "CHF 120 / hora"
         }
       },
@@ -1749,6 +1776,11 @@ export const translations = {
       pricing: "掲載している料金は目安です。最終的なお見積もりはプロジェクトの内容と優先度に合わせて調整いたします。",
       startingFrom: "開始料金",
       getStarted: "今すぐ始める",
+      heroHighlights: [
+        "ディスカバリー重視のキックオフセッション",
+        "明確なマイルストーンで進むデリバリー",
+        "保守しやすく文書化されたコード",
+      ],
       services: {
         fullstack: {
           title: "フルスタック開発",
@@ -1759,6 +1791,7 @@ export const translations = {
             "データベース設計と実装",
             "パフォーマンス最適化"
           ],
+          badge: "",
           price: "CHF 3,200"
         },
         frontend: {
@@ -1770,6 +1803,7 @@ export const translations = {
             "アニメーションと対話",
             "モバイルファースト設計"
           ],
+          badge: "一番人気",
           price: "CHF 1,600"
         },
         backend: {
@@ -1781,6 +1815,7 @@ export const translations = {
             "サーバー最適化",
             "セキュリティ実装"
           ],
+          badge: "",
           price: "CHF 1,900"
         },
         consulting: {
@@ -1792,6 +1827,7 @@ export const translations = {
             "パフォーマンス監査",
             "セキュリティ評価"
           ],
+          badge: "",
           price: "CHF 120 / 時間"
         }
       },
@@ -2197,6 +2233,11 @@ export const translations = {
       pricing: "列出的费用仅作起点，最终报价将根据您的项目范围与优先级量身定制。",
       startingFrom: "起价",
       getStarted: "开始",
+      heroHighlights: [
+        "以探索为核心的启动会",
+        "基于清晰里程碑的交付节奏",
+        "注重可维护性的完善文档代码",
+      ],
       services: {
         fullstack: {
           title: "全栈开发",
@@ -2207,6 +2248,7 @@ export const translations = {
             "数据库设计和实现",
             "性能优化"
           ],
+          badge: "",
           price: "CHF 3,200"
         },
         frontend: {
@@ -2218,6 +2260,7 @@ export const translations = {
             "动画和交互",
             "移动优先设计"
           ],
+          badge: "最受欢迎",
           price: "CHF 1,600"
         },
         backend: {
@@ -2229,6 +2272,7 @@ export const translations = {
             "服务器优化",
             "安全实现"
           ],
+          badge: "",
           price: "CHF 1,900"
         },
         consulting: {
@@ -2240,6 +2284,7 @@ export const translations = {
             "性能审计",
             "安全评估"
           ],
+          badge: "",
           price: "CHF 120 / 小时"
         }
       },

--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -399,66 +399,66 @@ export const translations = {
     },
     services: {
       title: "Services",
-      subtitle: "Focused development support for shipping faster.",
+      subtitle: "Four focused ways to work together.",
       backHome: "Back home",
-      pricing: "Choose the engagement that fits best—these rates are typical starting points and final estimates follow discovery.",
+      pricing: "Transparent starting points—pick what fits and we’ll shape the rest together.",
       startingFrom: "Starting from",
-      getStarted: "Get Started",
+      getStarted: "Start a project",
       heroHighlights: [
-        "Lightweight scopes, no surprises",
-        "Weekly progress check-ins",
+        "Lean kickoff, quick ramp",
+        "Weekly touchpoints included",
       ],
       services: {
         fullstack: {
           title: "Full Stack Development",
-          description: "Plan, build, and evolve complete web products end to end.",
+          description: "Build and evolve your product end to end.",
           features: [
-            "Architecture & scope definition",
-            "Frontend and backend implementation",
-            "Launch support and handover",
+            "Product scope",
+            "UI + API build",
+            "Launch follow-up",
           ],
           badge: "All-in-one",
           price: "CHF 3,200+"
         },
         frontend: {
           title: "Frontend Development",
-          description: "Craft responsive, accessible, and on-brand interfaces.",
+          description: "Polished React interfaces without extra overhead.",
           features: [
-            "Responsive React implementations",
-            "Design system rollouts",
-            "Interaction polish & accessibility",
+            "Responsive layouts",
+            "Design systems",
+            "Accessibility fixes",
           ],
-          badge: "Popular",
+          badge: "Most booked",
           price: "CHF 1,600+"
         },
         backend: {
           title: "Backend Development",
-          description: "Design dependable services that scale with your product.",
+          description: "Reliable services and data layers that scale.",
           features: [
-            "API and service architecture",
-            "Database modelling & migrations",
-            "Deployment and observability setup",
+            "API architecture",
+            "Data modelling",
+            "Observability setup",
           ],
           badge: "",
           price: "CHF 1,900+"
         },
         consulting: {
           title: "Technical Consulting",
-          description: "Get clarity on architecture, stack choices, and next steps.",
+          description: "Targeted guidance for teams and roadmaps.",
           features: [
-            "Architecture and stack reviews",
-            "Performance & security audits",
-            "Pairing sessions with your team",
+            "Architecture reviews",
+            "Performance audits",
+            "Pairing sessions",
           ],
           badge: "",
-          price: "CHF 120 / hour"
+          price: "CHF 120 / h"
         }
       },
       customRequirements: {
         title: "Need something custom?",
-        description: "If your scope doesn’t fit neatly into these packages, let’s outline a tailored collaboration.",
-        button: "Start a conversation",
-        note: "Share a quick overview and I'll respond within one business day."
+        description: "Brief doesn’t fit these packages? Let’s outline a tailored path together.",
+        button: "Talk about your scope",
+        note: "Share a quick snapshot and I'll reply within one business day."
       }
     },
   },
@@ -852,66 +852,66 @@ export const translations = {
     },
     services: {
       title: "Dienstleistungen",
-      subtitle: "Fokussierte Entwicklungsleistungen für schnelle Ergebnisse.",
+      subtitle: "Vier fokussierte Wege für eine Zusammenarbeit.",
       backHome: "Zurück",
-      pricing: "Wählen Sie das passende Angebot – die Beträge sind typische Einstiegspreise, das finale Angebot entsteht nach dem Kennenlernen.",
+      pricing: "Transparente Einstiegspreise – wir verfeinern das Angebot gemeinsam nach dem Kick-off.",
       startingFrom: "Ab",
-      getStarted: "Loslegen",
+      getStarted: "Projekt starten",
       heroHighlights: [
-        "Klare Projektumfänge ohne Überraschungen",
-        "Wöchentliche Status-Updates",
+        "Schlanker Start, schnelle Umsetzung",
+        "Wöchentliche Touchpoints inklusive",
       ],
       services: {
         fullstack: {
           title: "Full-Stack-Entwicklung",
-          description: "Konzipiere, entwickle und erweitere komplette Webprodukte aus einer Hand.",
+          description: "Produkt ganzheitlich planen, bauen und weiterentwickeln.",
           features: [
-            "Architektur- und Scope-Definition",
-            "Frontend- und Backend-Umsetzung",
-            "Begleitung bis zum Launch",
+            "Produkt-Scoping",
+            "UI + API Umsetzung",
+            "Launch-Begleitung",
           ],
-          badge: "Rundumpaket",
+          badge: "Alles aus einer Hand",
           price: "CHF 3'200+"
         },
         frontend: {
           title: "Frontend-Entwicklung",
-          description: "Baue reaktionsschnelle, zugängliche und markenkonforme Interfaces.",
+          description: "Hochwertige React-Interfaces ohne Ballast.",
           features: [
-            "Responsive React-Implementierungen",
-            "Design-System-Rollouts",
-            "Interaktions-Feinschliff & Barrierefreiheit",
+            "Responsives Layout",
+            "Design-Systeme",
+            "Accessibility-Optimierung",
           ],
-          badge: "Beliebt",
+          badge: "Meist gebucht",
           price: "CHF 1'600+"
         },
         backend: {
           title: "Backend-Entwicklung",
-          description: "Entwirf belastbare Services, die mit deinem Produkt skalieren.",
+          description: "Zuverlässige Services und Datenebenen, die mitwachsen.",
           features: [
-            "API- und Service-Architektur",
-            "Datenbankmodellierung & Migrationen",
-            "Deployment und Observability",
+            "API-Architektur",
+            "Datenmodellierung",
+            "Observability-Setup",
           ],
           badge: "",
           price: "CHF 1'900+"
         },
         consulting: {
           title: "Technische Beratung",
-          description: "Erhalte Klarheit bei Architektur, Stack-Auswahl und nächsten Schritten.",
+          description: "Gezielte technische Begleitung für Team und Roadmap.",
           features: [
-            "Architektur- & Stack-Reviews",
-            "Performance- und Security-Audits",
-            "Gemeinsame Sessions mit deinem Team",
+            "Architektur-Reviews",
+            "Performance-Audits",
+            "Pairing-Sessions",
           ],
           badge: "",
-          price: "CHF 120 / Stunde"
+          price: "CHF 120 / Std"
         }
       },
       customRequirements: {
         title: "Individuelle Anforderungen?",
-        description: "Ihr Vorhaben passt nicht in diese Pakete? Lassen Sie uns eine maßgeschneiderte Zusammenarbeit definieren.",
-        button: "Gespräch starten",
-        note: "Schicken Sie mir eine kurze Zusammenfassung – ich melde mich innerhalb eines Werktags."
+        description: "Passt Ihr Briefing nicht exakt? Wir skizzieren gemeinsam den richtigen Rahmen.",
+        button: "Individuelle Anfrage senden",
+        note: "Eine kurze Übersicht reicht – ich melde mich innerhalb eines Werktags."
       }
     },
   },
@@ -1305,66 +1305,66 @@ export const translations = {
     },
     services: {
       title: "Servicios",
-      subtitle: "Soporte de desarrollo enfocado para lanzar más rápido.",
+      subtitle: "Cuatro formas enfocadas de colaborar.",
       backHome: "Regresar",
-      pricing: "Elige el servicio que mejor encaje — estas tarifas son precios iniciales habituales y el presupuesto final llega tras la fase de discovery.",
+      pricing: "Tarifas iniciales transparentes; afinamos los detalles juntos tras la toma de requisitos.",
       startingFrom: "Desde",
-      getStarted: "Comenzar",
+      getStarted: "Iniciar proyecto",
       heroHighlights: [
-        "Alcances claros sin sorpresas",
-        "Revisiones de avance semanales",
+        "Inicio ágil, avance rápido",
+        "Reuniones semanales incluidas",
       ],
       services: {
         fullstack: {
           title: "Desarrollo Full Stack",
-          description: "Planificamos, construimos y evolucionamos productos web completos de principio a fin.",
+          description: "Construyo y hago crecer tu producto de punta a punta.",
           features: [
-            "Definición de arquitectura y alcance",
-            "Implementación frontend y backend",
-            "Acompañamiento en lanzamiento y traspaso",
+            "Alcance del producto",
+            "UI + API completas",
+            "Soporte de lanzamiento",
           ],
           badge: "Todo en uno",
           price: "CHF 3,200+"
         },
         frontend: {
           title: "Desarrollo Frontend",
-          description: "Diseñamos interfaces accesibles, responsivas y alineadas con tu marca.",
+          description: "Interfaces React pulidas sin sobrecarga.",
           features: [
-            "Implementaciones React responsivas",
-            "Despliegue de sistemas de diseño",
-            "Pulido de interacciones y accesibilidad",
+            "Diseños responsivos",
+            "Sistemas de diseño",
+            "Ajustes de accesibilidad",
           ],
-          badge: "Popular",
+          badge: "Más solicitado",
           price: "CHF 1,600+"
         },
         backend: {
           title: "Desarrollo Backend",
-          description: "Diseñamos servicios confiables que escalan con tu producto.",
+          description: "Servicios y datos fiables que escalan contigo.",
           features: [
-            "Arquitectura de APIs y servicios",
-            "Modelado y migraciones de bases de datos",
-            "Configuración de despliegue y observabilidad",
+            "Arquitectura de APIs",
+            "Modelado de datos",
+            "Configuración de observabilidad",
           ],
           badge: "",
           price: "CHF 1,900+"
         },
         consulting: {
           title: "Consultoría Técnica",
-          description: "Obtén claridad sobre arquitectura, stack y próximos pasos.",
+          description: "Acompañamiento técnico preciso para tu equipo.",
           features: [
-            "Revisiones de arquitectura y stack",
-            "Auditorías de rendimiento y seguridad",
-            "Sesiones de acompañamiento con tu equipo",
+            "Revisiones de arquitectura",
+            "Auditorías de rendimiento",
+            "Sesiones de pairing",
           ],
           badge: "",
-          price: "CHF 120 / hora"
+          price: "CHF 120 / h"
         }
       },
       customRequirements: {
         title: "¿Necesitas algo a medida?",
-        description: "Si tu proyecto no encaja en estos paquetes, definamos juntos una colaboración personalizada.",
-        button: "Iniciar conversación",
-        note: "Compárteme un resumen breve y te responderé en un día hábil."
+        description: "¿Tu necesidad es diferente? Definamos una colaboración a medida.",
+        button: "Hablar de un encargo a medida",
+        note: "Comparte un resumen breve y responderé en un día laborable."
       }
     }
   },
@@ -1759,66 +1759,66 @@ export const translations = {
     },
     services: {
       title: "サービス",
-      subtitle: "スピーディーなリリースを支える、集中型の開発サポート。",
+      subtitle: "4つのシンプルな協業プランです。",
       backHome: "ホームに戻る",
-      pricing: "プロジェクトに最適なプランをお選びください。表示料金は目安で、詳細なお見積もりはヒアリング後にご提示します。",
+      pricing: "起点となる料金を明示しています。内容に合わせて一緒に最終見積もりを整えましょう。",
       startingFrom: "開始料金",
-      getStarted: "今すぐ始める",
+      getStarted: "プロジェクトを始める",
       heroHighlights: [
-        "驚きのない明確なスコープ",
-        "週次の進捗チェックイン",
+        "短時間のキックオフ",
+        "毎週の進捗共有つき",
       ],
       services: {
         fullstack: {
           title: "フルスタック開発",
-          description: "構想から運用まで、一貫してWebプロダクトを並走開発します。",
+          description: "企画から運用まで、プロダクトを丸ごと伴走します。",
           features: [
-            "アーキテクチャとスコープ設計",
-            "フロント・バックエンド実装",
-            "ローンチ支援と引き継ぎ",
+            "要件スコープ整理",
+            "UI + API 実装",
+            "ローンチ後フォロー",
           ],
           badge: "ワンストップ",
           price: "CHF 3,200+"
         },
         frontend: {
           title: "フロントエンド開発",
-          description: "ブランドに寄り添った、アクセシブルで反応の良いUIを構築します。",
+          description: "余計な負担なく、洗練されたReactフロントエンドを。",
           features: [
-            "レスポンシブなReact実装",
+            "レスポンシブ設計",
             "デザインシステム導入",
-            "インタラクションとアクセシビリティ調整",
+            "アクセシビリティ改善",
           ],
-          badge: "人気",
+          badge: "人気プラン",
           price: "CHF 1,600+"
         },
         backend: {
           title: "バックエンド開発",
-          description: "プロダクトの成長に合わせてスケールする堅牢なサービスを設計します。",
+          description: "伸びるチームのための堅牢なサービスとデータ基盤。",
           features: [
-            "API・サービスアーキテクチャ",
-            "データベース設計と移行",
-            "デプロイと可観測性の整備",
+            "APIアーキテクチャ",
+            "データモデリング",
+            "監視とログ整備",
           ],
           badge: "",
           price: "CHF 1,900+"
         },
         consulting: {
           title: "技術コンサルティング",
-          description: "アーキテクチャや技術選定、次の一手を明確にします。",
+          description: "技術判断とチーム体制をピンポイントで支援します。",
           features: [
-            "アーキテクチャ／スタックレビュー",
-            "パフォーマンス＆セキュリティ診断",
-            "チームとの伴走セッション",
+            "アーキテクチャレビュー",
+            "パフォーマンス監査",
+            "ペアワークセッション",
           ],
           badge: "",
-          price: "CHF 120 / 時間"
+          price: "CHF 120 / 時"
         }
       },
       customRequirements: {
         title: "オーダーメイドが必要ですか？",
-        description: "既存プランに当てはまらない内容もお気軽にご相談ください。最適な進め方をご提案します。",
-        button: "相談してみる",
-        note: "概要をお送りいただければ、1営業日以内に折り返します。"
+        description: "パッケージに当てはまらない要件も歓迎です。最適な形を一緒に描きましょう。",
+        button: "カスタム相談をする",
+        note: "概要を少し共有いただければ、1営業日以内に返信します。"
       }
     }
   },
@@ -2212,56 +2212,56 @@ export const translations = {
     },
     services: {
       title: "服务",
-      subtitle: "聚焦高效交付的轻量化开发服务。",
+      subtitle: "四种专注的合作方式。",
       backHome: "返回首页",
-      pricing: "选择最适合的合作方式——以下金额为常见起步价，最终报价将在需求沟通后确认。",
+      pricing: "起步价清晰透明，细节会在沟通后一起定制。",
       startingFrom: "起价",
-      getStarted: "开始",
+      getStarted: "开启项目",
       heroHighlights: [
-        "范围清晰、过程透明",
-        "每周进度同步",
+        "快速启动",
+        "每周例行同步",
       ],
       services: {
         fullstack: {
           title: "全栈开发",
-          description: "从规划到上线，全程伴随构建完整的 Web 产品。",
+          description: "端到端陪伴你构建并迭代产品。",
           features: [
-            "架构与范围规划",
-            "前后端一体化实现",
-            "上线支持与交付交接",
+            "范围梳理",
+            "UI 与 API 开发",
+            "上线后支持",
           ],
           badge: "一站式",
           price: "CHF 3,200+"
         },
         frontend: {
           title: "前端开发",
-          description: "打造符合品牌的无障碍、响应式界面体验。",
+          description: "轻量交付精致的 React 界面。",
           features: [
-            "响应式 React 实现",
+            "自适应布局",
             "设计系统落地",
-            "交互与无障碍优化",
+            "无障碍优化",
           ],
-          badge: "热门",
+          badge: "最受欢迎",
           price: "CHF 1,600+"
         },
         backend: {
           title: "后端开发",
-          description: "设计可随业务扩展的稳定服务与数据层。",
+          description: "稳健的服务与数据层，随业务扩展。",
           features: [
-            "API 与服务架构设计",
-            "数据库建模与迁移",
-            "部署与可观测性配置",
+            "API 架构设计",
+            "数据建模",
+            "可观测性配置",
           ],
           badge: "",
           price: "CHF 1,900+"
         },
         consulting: {
           title: "技术咨询",
-          description: "为架构、技术选型与下一步行动提供清晰建议。",
+          description: "为团队与路线图提供精准技术指引。",
           features: [
-            "架构与技术栈评审",
-            "性能与安全诊断",
-            "团队协作辅导",
+            "架构评审",
+            "性能审计",
+            "协作陪练",
           ],
           badge: "",
           price: "CHF 120 / 小时"
@@ -2269,9 +2269,9 @@ export const translations = {
       },
       customRequirements: {
         title: "需要定制方案？",
-        description: "如果这些套餐无法覆盖您的需求，我们可以共同规划合适的合作方式。",
-        button: "发起交流",
-        note: "请先简单介绍项目背景，我会在1个工作日内回复。"
+        description: "需求不在以上方案？我们可以制定独立合作方式。",
+        button: "聊聊定制需求",
+        note: "简单介绍你的想法，我会在一个工作日内回复。"
       }
     }
   } 

--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -401,7 +401,8 @@ export const translations = {
       title: "Services",
       subtitle: "Comprehensive software development services tailored to your needs.",
       backHome: "Back home",
-      pricing: "* Prices are negotiable and will be tailored to your specific needs and project scope.",
+      pricing: "Listed rates are starting points—each proposal is tailored to match your project's scope and priorities.",
+      startingFrom: "Starting from",
       getStarted: "Get Started",
       services: {
         fullstack: {
@@ -412,7 +413,8 @@ export const translations = {
             "RESTful API development",
             "Database design and implementation",
             "Performance optimization"
-          ]
+          ],
+          price: "CHF 3,200"
         },
         frontend: {
           title: "Frontend Development",
@@ -422,7 +424,8 @@ export const translations = {
             "UI/UX implementation",
             "Animation and interactivity",
             "Mobile-first design"
-          ]
+          ],
+          price: "CHF 1,600"
         },
         backend: {
           title: "Backend Development",
@@ -432,7 +435,8 @@ export const translations = {
             "Database management",
             "Server optimization",
             "Security implementation"
-          ]
+          ],
+          price: "CHF 1,900"
         },
         consulting: {
           title: "Technical Consulting",
@@ -442,7 +446,8 @@ export const translations = {
             "Technology stack selection",
             "Performance auditing",
             "Security assessment"
-          ]
+          ],
+          price: "CHF 120 / hour"
         }
       },
       customRequirements: {
@@ -844,7 +849,8 @@ export const translations = {
       title: "Dienstleistungen",
       subtitle: "Umfassende Softwareentwicklungsdienste, angepasst an Ihre Bedürfnisse.",
       backHome: "Zurück",
-      pricing: "* Preise sind verhandelbar und werden auf Ihre spezifischen Bedürfnisse und den Projektumfang abgestimmt.",
+      pricing: "Die aufgeführten Preise dienen als Ausgangspunkt – das finale Angebot richtet sich nach Ihrem Projektumfang und Ihren Prioritäten.",
+      startingFrom: "Ab",
       getStarted: "Loslegen",
       services: {
         fullstack: {
@@ -855,7 +861,8 @@ export const translations = {
             "RESTful API-Entwicklung",
             "Datenbankdesign und -implementierung",
             "Leistungsoptimierung"
-          ]
+          ],
+          price: "CHF 3'200"
         },
         frontend: {
           title: "Frontend-Entwicklung",
@@ -865,7 +872,8 @@ export const translations = {
             "UI/UX-Implementierung",
             "Animation und Interaktivität",
             "Mobile-First-Design"
-          ]
+          ],
+          price: "CHF 1'600"
         },
         backend: {
           title: "Backend-Entwicklung",
@@ -875,7 +883,8 @@ export const translations = {
             "Datenbankverwaltung",
             "Server-Optimierung",
             "Sicherheitsimplementierung"
-          ]
+          ],
+          price: "CHF 1'900"
         },
         consulting: {
           title: "Technische Beratung",
@@ -885,7 +894,8 @@ export const translations = {
             "Technologie-Stack-Auswahl",
             "Performance-Auditing",
             "Sicherheitsbewertung"
-          ]
+          ],
+          price: "CHF 120 / Stunde"
         }
       },
       customRequirements: {
@@ -1287,7 +1297,8 @@ export const translations = {
       title: "Servicios",
       subtitle: "Servicios integrales de desarrollo de software adaptados a sus necesidades, entregados con experiencia y precisión.",
       backHome: "Regresar",
-      pricing: "* Precios negociables y ajustados a sus necesidades específicas y al alcance del proyecto.",
+      pricing: "Las tarifas indicadas son un punto de partida; la propuesta final se ajusta al alcance y prioridades de su proyecto.",
+      startingFrom: "Desde",
       getStarted: "Comenzar",
       services: {
         fullstack: {
@@ -1298,7 +1309,8 @@ export const translations = {
             "Desarrollo de API RESTful",
             "Diseño e implementación de bases de datos",
             "Optimización de rendimiento"
-          ]
+          ],
+          price: "CHF 3,200"
         },
         frontend: {
           title: "Desarrollo Frontend",
@@ -1308,7 +1320,8 @@ export const translations = {
             "Implementación de UI/UX",
             "Animación e interactividad",
             "Diseño mobile-first"
-          ]
+          ],
+          price: "CHF 1,600"
         },
         backend: {
           title: "Desarrollo Backend",
@@ -1318,7 +1331,8 @@ export const translations = {
             "Administración de bases de datos",
             "Optimización de servidores",
             "Implementación de seguridad"
-          ]
+          ],
+          price: "CHF 1,900"
         },
         consulting: {
           title: "Consultoría Técnica",
@@ -1328,7 +1342,8 @@ export const translations = {
             "Selección de pila tecnológica",
             "Auditoría de rendimiento",
             "Evaluación de seguridad"
-          ]
+          ],
+          price: "CHF 120 / hora"
         }
       },
       customRequirements: {
@@ -1731,7 +1746,8 @@ export const translations = {
       title: "サービス",
       subtitle: "お客様のニーズに合わせた包括的なソフトウェア開発サービス。",
       backHome: "ホームに戻る",
-      pricing: "* 料金は交渉可能で、お客様の具体的なニーズとプロジェクトの規模に応じて調整します。",
+      pricing: "掲載している料金は目安です。最終的なお見積もりはプロジェクトの内容と優先度に合わせて調整いたします。",
+      startingFrom: "開始料金",
       getStarted: "今すぐ始める",
       services: {
         fullstack: {
@@ -1742,7 +1758,8 @@ export const translations = {
             "RESTful API開発",
             "データベース設計と実装",
             "パフォーマンス最適化"
-          ]
+          ],
+          price: "CHF 3,200"
         },
         frontend: {
           title: "フロントエンド開発",
@@ -1752,7 +1769,8 @@ export const translations = {
             "UI/UX実装",
             "アニメーションと対話",
             "モバイルファースト設計"
-          ]
+          ],
+          price: "CHF 1,600"
         },
         backend: {
           title: "バックエンド開発",
@@ -1762,7 +1780,8 @@ export const translations = {
             "データベース管理",
             "サーバー最適化",
             "セキュリティ実装"
-          ]
+          ],
+          price: "CHF 1,900"
         },
         consulting: {
           title: "技術コンサルティング",
@@ -1772,7 +1791,8 @@ export const translations = {
             "技術スタックの選定",
             "パフォーマンス監査",
             "セキュリティ評価"
-          ]
+          ],
+          price: "CHF 120 / 時間"
         }
       },
       customRequirements: {
@@ -2174,8 +2194,9 @@ export const translations = {
       title: "服务",
       subtitle: "根据您的需求定制的全面软件开发服务。",
       backHome: "返回首页",
-      pricing: "* 价格可协商，将根据您的具体需求和项目范围进行调整。",
-      getStarted: "开始", 
+      pricing: "列出的费用仅作起点，最终报价将根据您的项目范围与优先级量身定制。",
+      startingFrom: "起价",
+      getStarted: "开始",
       services: {
         fullstack: {
           title: "全栈开发",
@@ -2185,7 +2206,8 @@ export const translations = {
             "RESTful API开发",
             "数据库设计和实现",
             "性能优化"
-          ]
+          ],
+          price: "CHF 3,200"
         },
         frontend: {
           title: "前端开发",
@@ -2195,7 +2217,8 @@ export const translations = {
             "UI/UX实现",
             "动画和交互",
             "移动优先设计"
-          ]
+          ],
+          price: "CHF 1,600"
         },
         backend: {
           title: "后端开发",
@@ -2205,7 +2228,8 @@ export const translations = {
             "数据库管理",
             "服务器优化",
             "安全实现"
-          ]
+          ],
+          price: "CHF 1,900"
         },
         consulting: {
           title: "技术咨询",
@@ -2215,7 +2239,8 @@ export const translations = {
             "技术栈选择",
             "性能审计",
             "安全评估"
-          ]
+          ],
+          price: "CHF 120 / 小时"
         }
       },
       customRequirements: {

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -89,7 +89,7 @@ const Services = () => {
       </ScrollReveal>
 
       <ScrollReveal variant="default">
-        <p className="text-primary/80 text-sm mb-8 sm:mb-12 max-w-2xl italic">
+        <p className="text-primary/80 text-sm mb-8 sm:mb-12 max-w-2xl">
           {t.services.pricing}
         </p>
       </ScrollReveal>
@@ -100,61 +100,70 @@ const Services = () => {
             <motion.div
               onHoverStart={() => setHoveredService(service.key)}
               onHoverEnd={() => setHoveredService(null)}
-              className="p-5 sm:p-6 rounded-lg border border-foreground/10 
-                         bg-foreground/5 backdrop-blur-sm transition-all duration-300 
+              className="relative group flex flex-col p-5 sm:p-6 rounded-lg border border-foreground/10
+                         bg-foreground/5 backdrop-blur-sm transition-all duration-300
                          hover:border-primary/20 hover:bg-primary/5 cursor-default"
             >
-                {service.highlight && (
-                  <div className="absolute -top-3 left-1/2 -translate-x-1/2 px-3 py-0.5 
-                               bg-primary text-primary-foreground text-xs rounded-full
-                               font-medium shadow-sm">
-                    {service.highlight}
-                  </div>
-                )}
-                
-                <div className="flex items-center gap-3 mb-4">
-                  <div className="p-2.5 rounded-lg bg-gradient-to-br from-accent/20 to-transparent
-                              group-hover:from-primary/20 group-hover:to-transparent transition-all duration-300">
-                    <service.icon 
-                      className={`w-6 h-6 transition-colors duration-300
-                                ${hoveredService === service.key 
-                                  ? 'text-primary' 
-                                  : 'text-primary/80'}`}
-                    />
-                  </div>
-                  <h3 className="text-lg font-medium text-foreground group-hover:text-primary transition-colors">
-                    {t.services.services[service.key].title}
-                  </h3>
+              {service.highlight && (
+                <div className="absolute -top-3 left-1/2 -translate-x-1/2 px-3 py-0.5
+                             bg-primary text-primary-foreground text-xs rounded-full
+                             font-medium shadow-sm">
+                  {service.highlight}
                 </div>
-                
-                <p className="text-sm text-foreground/70 mb-6">
-                  {t.services.services[service.key].description}
-                </p>
+              )}
 
-                <ul className="space-y-3">
-                  {t.services.services[service.key].features.map((feature, i) => (
-                    <li 
-                      key={i}
-                      className="flex items-start gap-2.5 text-sm text-foreground/70
-                               group-hover:text-foreground/80 transition-colors"
-                    >
-                      <CheckCircle2 className="w-4 h-4 text-primary/80 group-hover:text-primary shrink-0 mt-0.5
-                                           transition-colors" />
-                      <span>{feature}</span>
-                    </li>
-                  ))}
-                </ul>
-
-                {/* service contact button */}
-                <div className="mt-6">
-                  <Link to={getServiceContactUrl(service.key)}>
-                    <IconButton 
-                      variant="default" 
-                      className="w-full justify-between border-accent/50 group-hover:border-primary/50 text-sm"
-                      label={t.services.getStarted || "Get Started"}
-                    />
-                  </Link>
+              <div className="flex items-center gap-3 mb-4">
+                <div className="p-2.5 rounded-lg bg-gradient-to-br from-accent/20 to-transparent
+                            group-hover:from-primary/20 group-hover:to-transparent transition-all duration-300">
+                  <service.icon
+                    className={`w-6 h-6 transition-colors duration-300
+                              ${hoveredService === service.key
+                                ? 'text-primary'
+                                : 'text-primary/80'}`}
+                  />
                 </div>
+                <h3 className="text-lg font-medium text-foreground group-hover:text-primary transition-colors">
+                  {t.services.services[service.key].title}
+                </h3>
+              </div>
+
+              <p className="text-sm text-foreground/70 mb-6">
+                {t.services.services[service.key].description}
+              </p>
+
+              <ul className="space-y-3 flex-1">
+                {t.services.services[service.key].features.map((feature, i) => (
+                  <li
+                    key={i}
+                    className="flex items-start gap-2.5 text-sm text-foreground/70
+                             group-hover:text-foreground/80 transition-colors"
+                  >
+                    <CheckCircle2 className="w-4 h-4 text-primary/80 group-hover:text-primary shrink-0 mt-0.5
+                                         transition-colors" />
+                    <span>{feature}</span>
+                  </li>
+                ))}
+              </ul>
+
+              {/* service pricing & contact */}
+              <div className="mt-6 space-y-4">
+                <div>
+                  <p className="text-xs uppercase tracking-wide text-foreground/60">
+                    {t.services.startingFrom}
+                  </p>
+                  <p className="text-lg font-semibold text-foreground">
+                    {t.services.services[service.key].price}
+                  </p>
+                </div>
+
+                <Link to={getServiceContactUrl(service.key)}>
+                  <IconButton
+                    variant="default"
+                    className="w-full justify-between border-accent/50 group-hover:border-primary/50 text-sm"
+                    label={t.services.getStarted || "Get Started"}
+                  />
+                </Link>
+              </div>
             </motion.div>
           </ScrollReveal>
         ))}

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -6,193 +6,268 @@
  * Refer to LICENSE for details or contact yanis.sebastian.zuercher@gmail.com for permissions.
  */
 
-import { useState } from "react";
-import { Code2, Blocks, Database, Lightbulb, ArrowRightIcon, CheckCircle2} from "lucide-react";
-import { Link, useNavigate } from "react-router-dom";
+import { Code2, Blocks, Database, Lightbulb, ArrowRightIcon, CheckCircle2, type LucideIcon } from "lucide-react";
+import { Link } from "react-router-dom";
 import { motion } from "motion/react";
 import { useLanguage } from "@/lib/language-provider";
 import { translations, type Translation } from "@/lib/translations";
-import { Button } from "@/components/ui/button";
 import { Helmet } from "react-helmet-async";
 import { IconButton } from "@/components/ui/custom/IconButton";
 import ScrollReveal from "@/components/ScrollReveal";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+
+type ServiceKey = keyof Translation["services"]["services"];
+
+const servicesList: Array<{ key: ServiceKey; icon: LucideIcon }> = [
+  {
+    icon: Code2,
+    key: "fullstack",
+  },
+  {
+    icon: Blocks,
+    key: "frontend",
+  },
+  {
+    icon: Database,
+    key: "backend",
+  },
+  {
+    icon: Lightbulb,
+    key: "consulting",
+  },
+];
+
+const serviceStyles: Record<
+  ServiceKey,
+  {
+    accent: string;
+    hoverAccent: string;
+    iconBg: string;
+    iconColor: string;
+    badge: string;
+    shadow: string;
+  }
+> = {
+  fullstack: {
+    accent: "from-sky-500/20 via-sky-500/5 to-transparent",
+    hoverAccent: "from-sky-500/35 via-sky-500/10 to-transparent",
+    iconBg: "bg-sky-500/15 group-hover:bg-sky-500/20",
+    iconColor: "text-sky-400 group-hover:text-sky-300",
+    badge: "border-sky-400/40 bg-sky-400/10 text-sky-100/90",
+    shadow: "hover:shadow-[0_30px_60px_-35px_rgba(56,189,248,0.75)]",
+  },
+  frontend: {
+    accent: "from-rose-500/20 via-rose-500/5 to-transparent",
+    hoverAccent: "from-rose-500/35 via-rose-500/10 to-transparent",
+    iconBg: "bg-rose-500/15 group-hover:bg-rose-500/20",
+    iconColor: "text-rose-400 group-hover:text-rose-300",
+    badge: "border-rose-400/40 bg-rose-400/10 text-rose-100/90",
+    shadow: "hover:shadow-[0_30px_60px_-35px_rgba(244,114,182,0.75)]",
+  },
+  backend: {
+    accent: "from-violet-500/20 via-violet-500/5 to-transparent",
+    hoverAccent: "from-violet-500/35 via-violet-500/10 to-transparent",
+    iconBg: "bg-violet-500/15 group-hover:bg-violet-500/20",
+    iconColor: "text-violet-400 group-hover:text-violet-300",
+    badge: "border-violet-400/40 bg-violet-400/10 text-violet-100/90",
+    shadow: "hover:shadow-[0_30px_60px_-35px_rgba(167,139,250,0.75)]",
+  },
+  consulting: {
+    accent: "from-amber-500/20 via-amber-500/5 to-transparent",
+    hoverAccent: "from-amber-500/35 via-amber-500/10 to-transparent",
+    iconBg: "bg-amber-500/15 group-hover:bg-amber-500/20",
+    iconColor: "text-amber-400 group-hover:text-amber-300",
+    badge: "border-amber-400/40 bg-amber-400/10 text-amber-100/90",
+    shadow: "hover:shadow-[0_30px_60px_-35px_rgba(251,191,36,0.7)]",
+  },
+};
 
 const Services = () => {
-  const [hoveredService, setHoveredService] = useState<string | null>(null);
   const { language } = useLanguage();
   const t = translations[language] as Translation;
-  const navigate = useNavigate();
 
-  const servicesList = [
-    {
-      icon: Code2,
-      key: 'fullstack',
-    },
-    {
-      icon: Blocks,
-      key: 'frontend',
-      highlight: 'Most Popular'
-    },
-    {
-      icon: Database,
-      key: 'backend'
-    },
-    {
-      icon: Lightbulb,
-      key: 'consulting'
-    }
-  ];
-
-  // create service contact url
-  // TODO: use intl
-  const getServiceContactUrl = (serviceKey: string) => {
-    const serviceNames = {
+  const getServiceContactUrl = (serviceKey: ServiceKey) => {
+    const serviceNames: Record<ServiceKey, string> = {
       fullstack: "Full-Stack Development",
-      frontend: "Frontend Development", 
+      frontend: "Frontend Development",
       backend: "Backend Development",
-      consulting: "Technical Consulting"
+      consulting: "Technical Consulting",
     };
 
-    const serviceMessages = {
+    const serviceMessages: Record<ServiceKey, string> = {
       fullstack: `Hi Yanis,\n\nI'm interested in your Full-Stack Development services. I need help building a complete web application from frontend to backend.\n\nI'd like to discuss:\n- Project requirements and timeline\n- Technology stack recommendations\n- Development approach and best practices\n\nLooking forward to hearing from you!`,
-      
       frontend: `Hi Yanis,\n\nI'm interested in your Frontend Development services. I need help creating a modern, responsive user interface.\n\nI'd like to discuss:\n- UI/UX implementation\n- React/Next.js development\n- Performance optimization\n- Mobile responsiveness\n\nLooking forward to your response!`,
-      
       backend: `Hi Yanis,\n\nI'm interested in your Backend Development services. I need help building robust server-side solutions.\n\nI'd like to discuss:\n- API development and design\n- Database architecture\n- Server infrastructure\n- Security implementation\n\nLooking forward to hearing from you!`,
-      
-      consulting: `Hi Yanis,\n\nI'm interested in your Technical Consulting services. I need guidance on technical decisions and architecture.\n\nI'd like to discuss:\n- Technology stack evaluation\n- Architecture review and recommendations\n- Code review and best practices\n- Performance optimization strategies\n\nLooking forward to your expertise!`
+      consulting: `Hi Yanis,\n\nI'm interested in your Technical Consulting services. I need guidance on technical decisions and architecture.\n\nI'd like to discuss:\n- Technology stack evaluation\n- Architecture review and recommendations\n- Code review and best practices\n- Performance optimization strategies\n\nLooking forward to your expertise!`,
     };
 
-    const subject = `${serviceNames[serviceKey as keyof typeof serviceNames]} Inquiry`;
-    const message = serviceMessages[serviceKey as keyof typeof serviceMessages];
+    const subject = `${serviceNames[serviceKey]} Inquiry`;
+    const message = serviceMessages[serviceKey];
 
     return `/contact?subject=${encodeURIComponent(subject)}&message=${encodeURIComponent(message)}`;
   };
 
+  const heroHighlights = t.services.heroHighlights ?? [];
+
   return (
-    <div className="flex flex-col w-full">
+    <div className="flex w-full flex-col gap-12">
       <Helmet>
         <title>{t.seo.services.title}</title>
         <meta name="description" content={t.seo.services.description} />
       </Helmet>
 
-      <ScrollReveal variant="pageTitle">
-        <h1 className="text-4xl font-bold mb-6 sm:mb-6">
-          {t.services.title}
-        </h1>
-      </ScrollReveal>
+      <section className="relative overflow-hidden rounded-[2rem] border border-foreground/10 bg-gradient-to-br from-background via-background/40 to-background px-6 py-10 sm:px-10 sm:py-12">
+        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(56,189,248,0.18),transparent_55%)]" />
+        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_bottom_right,rgba(168,85,247,0.18),transparent_55%)]" />
 
-      <ScrollReveal variant="default">
-        <p className="text-foreground/60 mb-4 max-w-2xl">
-          {t.services.subtitle}
-        </p>
-      </ScrollReveal>
-
-      <ScrollReveal variant="default">
-        <p className="text-primary/80 text-sm mb-8 sm:mb-12 max-w-2xl">
-          {t.services.pricing}
-        </p>
-      </ScrollReveal>
-
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 sm:gap-6 mb-8 sm:mb-12">
-        {servicesList.map((service, index) => (
-          <ScrollReveal key={service.key} variant="default" delay={index * 140}>
-            <motion.div
-              onHoverStart={() => setHoveredService(service.key)}
-              onHoverEnd={() => setHoveredService(null)}
-              className="relative group flex flex-col p-5 sm:p-6 rounded-lg border border-foreground/10
-                         bg-foreground/5 backdrop-blur-sm transition-all duration-300
-                         hover:border-primary/20 hover:bg-primary/5 cursor-default"
-            >
-              {service.highlight && (
-                <div className="absolute -top-3 left-1/2 -translate-x-1/2 px-3 py-0.5
-                             bg-primary text-primary-foreground text-xs rounded-full
-                             font-medium shadow-sm">
-                  {service.highlight}
-                </div>
-              )}
-
-              <div className="flex items-center gap-3 mb-4">
-                <div className="p-2.5 rounded-lg bg-gradient-to-br from-accent/20 to-transparent
-                            group-hover:from-primary/20 group-hover:to-transparent transition-all duration-300">
-                  <service.icon
-                    className={`w-6 h-6 transition-colors duration-300
-                              ${hoveredService === service.key
-                                ? 'text-primary'
-                                : 'text-primary/80'}`}
-                  />
-                </div>
-                <h3 className="text-lg font-medium text-foreground group-hover:text-primary transition-colors">
-                  {t.services.services[service.key].title}
-                </h3>
-              </div>
-
-              <p className="text-sm text-foreground/70 mb-6">
-                {t.services.services[service.key].description}
-              </p>
-
-              <ul className="space-y-3 flex-1">
-                {t.services.services[service.key].features.map((feature, i) => (
-                  <li
-                    key={i}
-                    className="flex items-start gap-2.5 text-sm text-foreground/70
-                             group-hover:text-foreground/80 transition-colors"
-                  >
-                    <CheckCircle2 className="w-4 h-4 text-primary/80 group-hover:text-primary shrink-0 mt-0.5
-                                         transition-colors" />
-                    <span>{feature}</span>
-                  </li>
-                ))}
-              </ul>
-
-              {/* service pricing & contact */}
-              <div className="mt-6 space-y-4">
-                <div>
-                  <p className="text-xs uppercase tracking-wide text-foreground/60">
-                    {t.services.startingFrom}
-                  </p>
-                  <p className="text-lg font-semibold text-foreground">
-                    {t.services.services[service.key].price}
-                  </p>
-                </div>
-
-                <Link to={getServiceContactUrl(service.key)}>
-                  <IconButton
-                    variant="default"
-                    className="w-full justify-between border-accent/50 group-hover:border-primary/50 text-sm"
-                    label={t.services.getStarted || "Get Started"}
-                  />
-                </Link>
-              </div>
-            </motion.div>
+        <div className="relative z-10 flex flex-col gap-8">
+          <ScrollReveal variant="pageTitle" className="space-y-6">
+            <div className="inline-flex w-fit items-center gap-2 rounded-full border border-primary/30 bg-primary/10 px-3 py-1 text-xs font-medium uppercase tracking-[0.28em] text-primary/90">
+              {t.services.title}
+            </div>
+            <h1 className="text-4xl font-semibold leading-tight text-foreground sm:text-5xl">
+              {t.services.subtitle}
+            </h1>
+            <p className="max-w-2xl text-sm leading-relaxed text-foreground/65 sm:text-base">
+              {t.services.pricing}
+            </p>
           </ScrollReveal>
-        ))}
+
+          {heroHighlights.length > 0 && (
+            <ScrollReveal variant="default" delay={120}>
+              <div className="grid gap-3 sm:grid-cols-3">
+                {heroHighlights.map((item, index) => (
+                  <div
+                    key={index}
+                    className="flex items-start gap-2 rounded-xl border border-foreground/10 bg-background/70 p-3 text-sm text-foreground/70 shadow-sm backdrop-blur"
+                  >
+                    <CheckCircle2 className="mt-0.5 h-4 w-4 text-primary" />
+                    <span className="leading-snug">{item}</span>
+                  </div>
+                ))}
+              </div>
+            </ScrollReveal>
+          )}
+
+          <ScrollReveal variant="default" delay={160}>
+            <div>
+              <Link to="/contact">
+                <IconButton
+                  className="w-full bg-primary text-primary-foreground shadow-lg shadow-primary/20 hover:bg-primary/90 sm:w-auto"
+                  icon={<ArrowRightIcon />}
+                  label={t.services.getStarted || "Get Started"}
+                />
+              </Link>
+            </div>
+          </ScrollReveal>
+        </div>
+      </section>
+
+      <div className="grid grid-cols-1 gap-5 md:grid-cols-2 xl:gap-6">
+        {servicesList.map((service, index) => {
+          const style = serviceStyles[service.key];
+          const serviceContent = t.services.services[service.key];
+          const badgeLabel = serviceContent.badge;
+
+          return (
+            <ScrollReveal key={service.key} variant="default" delay={index * 120}>
+              <motion.div
+                whileHover={{ translateY: -8 }}
+                transition={{ type: "spring", stiffness: 240, damping: 22 }}
+                className={cn(
+                  "group relative flex h-full flex-col overflow-hidden rounded-3xl border border-foreground/10 bg-background/80 p-6 sm:p-7 transition-all duration-300 backdrop-blur",
+                  style.shadow
+                )}
+              >
+                <div className={cn("pointer-events-none absolute inset-0 rounded-3xl bg-gradient-to-br opacity-70", style.accent)} />
+                <div
+                  className={cn(
+                    "pointer-events-none absolute inset-0 rounded-3xl bg-gradient-to-br opacity-0 transition-opacity duration-300 group-hover:opacity-100",
+                    style.hoverAccent
+                  )}
+                />
+
+                <div className="relative z-10 flex h-full flex-col gap-6">
+                  <div className="flex items-start justify-between gap-4">
+                    <div className={cn("rounded-2xl p-3 transition-colors duration-300", style.iconBg)}>
+                      <service.icon className={cn("h-6 w-6 transition-colors duration-300", style.iconColor)} />
+                    </div>
+                    {badgeLabel && (
+                      <Badge className={cn("border text-xs font-medium uppercase tracking-[0.2em] backdrop-blur", style.badge)}>
+                        {badgeLabel}
+                      </Badge>
+                    )}
+                  </div>
+
+                  <div className="space-y-3">
+                    <h3 className="text-xl font-semibold text-foreground">{serviceContent.title}</h3>
+                    <p className="text-sm leading-relaxed text-foreground/70">{serviceContent.description}</p>
+                  </div>
+
+                  <div className="grid flex-1 grid-cols-1 gap-3 text-sm sm:grid-cols-2">
+                    {serviceContent.features.map((feature, featureIndex) => (
+                      <div
+                        key={featureIndex}
+                        className="flex items-start gap-2 rounded-2xl border border-transparent bg-foreground/[0.02] p-3 transition-all duration-300 group-hover:border-foreground/10 group-hover:bg-foreground/[0.04]"
+                      >
+                        <CheckCircle2 className="mt-0.5 h-4 w-4 flex-shrink-0 text-primary/80" />
+                        <span className="leading-snug text-foreground/70 group-hover:text-foreground/80">{feature}</span>
+                      </div>
+                    ))}
+                  </div>
+
+                  <div className="mt-2 space-y-4">
+                    <div className="flex flex-col gap-1 rounded-2xl border border-dashed border-foreground/15 bg-background/80 p-4">
+                      <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-foreground/50">
+                        {t.services.startingFrom}
+                      </span>
+                      <span className="text-2xl font-semibold text-foreground">{serviceContent.price}</span>
+                    </div>
+
+                    <Link to={getServiceContactUrl(service.key)} className="block">
+                      <IconButton
+                        variant="outline"
+                        className="w-full justify-between border-foreground/20 bg-background/80 text-sm hover:border-primary/40 hover:bg-primary/10"
+                        label={t.services.getStarted || "Get Started"}
+                        icon={<ArrowRightIcon />}
+                      />
+                    </Link>
+                  </div>
+                </div>
+              </motion.div>
+            </ScrollReveal>
+          );
+        })}
       </div>
 
-      {/* custom requirements */}
       <ScrollReveal variant="default">
-        <div className="relative overflow-hidden rounded-xl p-5 sm:p-6 md:p-8
-                       bg-gradient-to-br from-primary/20 via-primary/10 to-background
-                       border border-primary/20 backdrop-blur-sm">
-          <div className="relative z-10">
-            <h2 className="text-xl font-medium mb-3 text-foreground">
-              {t.services.customRequirements.title}
-            </h2>
-            <p className="text-sm text-foreground/70 mb-6 max-w-2xl">
-              {t.services.customRequirements.description}
-            </p>
-            <Link to="/contact?subject=Custom%20Development%20Requirements&message=Hi%20Yanis%2C%0A%0AI%20have%20specific%20requirements%20that%20don%27t%20fit%20standard%20service%20categories.%20I%27d%20like%20to%20discuss%20a%20custom%20solution.%0A%0AProject%20details%3A%0A-%20%0A-%20%0A-%20%0A%0ALooking%20forward%20to%20discussing%20this%20further%21">
-              <IconButton
-                className="group bg-primary transition-all duration-300"
+        <div className="relative overflow-hidden rounded-[2rem] border border-primary/20 bg-gradient-to-br from-primary/15 via-primary/5 to-background px-6 py-10 sm:px-10 sm:py-12">
+          <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(255,255,255,0.22),transparent_55%)]" />
+          <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_bottom_left,rgba(255,255,255,0.18),transparent_55%)]" />
+
+          <div className="relative z-10 grid gap-8 md:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)] md:items-center">
+            <div className="space-y-4">
+              <h2 className="text-2xl font-semibold text-foreground sm:text-3xl">{t.services.customRequirements.title}</h2>
+              <p className="text-sm leading-relaxed text-foreground/70 sm:text-base">
+                {t.services.customRequirements.description}
+              </p>
+            </div>
+
+            <div className="flex flex-col gap-4 rounded-2xl border border-white/20 bg-background/80 p-6 shadow-lg shadow-primary/10 backdrop-blur">
+              <p className="text-sm text-foreground/65">{t.services.pricing}</p>
+              <Link
+                to="/contact?subject=Custom%20Development%20Requirements&message=Hi%20Yanis%2C%0A%0AI%20have%20specific%20requirements%20that%20don%27t%20fit%20standard%20service%20categories.%20I%27d%20like%20to%20discuss%20a%20custom%20solution.%0A%0AProject%20details%3A%0A-%20%0A-%20%0A-%20%0A%0ALooking%20forward%20to%20discussing%20this%20further%21"
+                className="w-full"
               >
-                {t.services.customRequirements.button}
-              </IconButton>
-            </Link>
+                <IconButton
+                  className="w-full bg-primary text-primary-foreground shadow-lg shadow-primary/20 hover:bg-primary/90"
+                  icon={<ArrowRightIcon />}
+                  label={t.services.customRequirements.button}
+                />
+              </Link>
+            </div>
           </div>
-          
-          {/* decorative elemets */}
-          <div className="absolute top-0 right-0 w-48 h-48 bg-primary/5 rounded-full -translate-y-1/2 translate-x-1/2" />
-          <div className="absolute bottom-0 left-0 w-32 h-32 bg-primary/5 rounded-full translate-y-1/2 -translate-x-1/2" />
         </div>
       </ScrollReveal>
     </div>

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -41,45 +41,35 @@ const servicesList: Array<{ key: ServiceKey; icon: LucideIcon }> = [
 const serviceStyles: Record<
   ServiceKey,
   {
-    accent: string;
-    hoverAccent: string;
+    border: string;
     iconBg: string;
     iconColor: string;
     badge: string;
-    shadow: string;
   }
 > = {
   fullstack: {
-    accent: "from-sky-500/20 via-sky-500/5 to-transparent",
-    hoverAccent: "from-sky-500/35 via-sky-500/10 to-transparent",
-    iconBg: "bg-sky-500/15 group-hover:bg-sky-500/20",
-    iconColor: "text-sky-400 group-hover:text-sky-300",
-    badge: "border-sky-400/40 bg-sky-400/10 text-sky-100/90",
-    shadow: "hover:shadow-[0_30px_60px_-35px_rgba(56,189,248,0.75)]",
+    border: "hover:border-sky-400/40",
+    iconBg: "bg-sky-500/10",
+    iconColor: "text-sky-400",
+    badge: "border-sky-400/30 bg-sky-400/10 text-sky-400",
   },
   frontend: {
-    accent: "from-rose-500/20 via-rose-500/5 to-transparent",
-    hoverAccent: "from-rose-500/35 via-rose-500/10 to-transparent",
-    iconBg: "bg-rose-500/15 group-hover:bg-rose-500/20",
-    iconColor: "text-rose-400 group-hover:text-rose-300",
-    badge: "border-rose-400/40 bg-rose-400/10 text-rose-100/90",
-    shadow: "hover:shadow-[0_30px_60px_-35px_rgba(244,114,182,0.75)]",
+    border: "hover:border-rose-400/40",
+    iconBg: "bg-rose-500/10",
+    iconColor: "text-rose-400",
+    badge: "border-rose-400/30 bg-rose-400/10 text-rose-400",
   },
   backend: {
-    accent: "from-violet-500/20 via-violet-500/5 to-transparent",
-    hoverAccent: "from-violet-500/35 via-violet-500/10 to-transparent",
-    iconBg: "bg-violet-500/15 group-hover:bg-violet-500/20",
-    iconColor: "text-violet-400 group-hover:text-violet-300",
-    badge: "border-violet-400/40 bg-violet-400/10 text-violet-100/90",
-    shadow: "hover:shadow-[0_30px_60px_-35px_rgba(167,139,250,0.75)]",
+    border: "hover:border-violet-400/40",
+    iconBg: "bg-violet-500/10",
+    iconColor: "text-violet-400",
+    badge: "border-violet-400/30 bg-violet-400/10 text-violet-400",
   },
   consulting: {
-    accent: "from-amber-500/20 via-amber-500/5 to-transparent",
-    hoverAccent: "from-amber-500/35 via-amber-500/10 to-transparent",
-    iconBg: "bg-amber-500/15 group-hover:bg-amber-500/20",
-    iconColor: "text-amber-400 group-hover:text-amber-300",
-    badge: "border-amber-400/40 bg-amber-400/10 text-amber-100/90",
-    shadow: "hover:shadow-[0_30px_60px_-35px_rgba(251,191,36,0.7)]",
+    border: "hover:border-amber-400/40",
+    iconBg: "bg-amber-500/10",
+    iconColor: "text-amber-400",
+    badge: "border-amber-400/30 bg-amber-400/10 text-amber-400",
   },
 };
 
@@ -117,44 +107,42 @@ const Services = () => {
         <meta name="description" content={t.seo.services.description} />
       </Helmet>
 
-      <section className="relative overflow-hidden rounded-[2rem] border border-foreground/10 bg-gradient-to-br from-background via-background/40 to-background px-6 py-10 sm:px-10 sm:py-12">
-        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(56,189,248,0.18),transparent_55%)]" />
-        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_bottom_right,rgba(168,85,247,0.18),transparent_55%)]" />
-
-        <div className="relative z-10 flex flex-col gap-8">
-          <ScrollReveal variant="pageTitle" className="space-y-6">
-            <div className="inline-flex w-fit items-center gap-2 rounded-full border border-primary/30 bg-primary/10 px-3 py-1 text-xs font-medium uppercase tracking-[0.28em] text-primary/90">
+      <section className="rounded-[2rem] border border-foreground/10 bg-background/80 px-6 py-10 sm:px-10 sm:py-12">
+        <div className="flex flex-col gap-8 md:flex-row md:items-end md:justify-between">
+          <ScrollReveal variant="pageTitle" className="space-y-6 md:max-w-2xl">
+            <div className="inline-flex w-fit items-center gap-2 rounded-full border border-foreground/20 px-3 py-1 text-xs font-medium uppercase tracking-[0.28em] text-foreground/60">
               {t.services.title}
             </div>
-            <h1 className="text-4xl font-semibold leading-tight text-foreground sm:text-5xl">
-              {t.services.subtitle}
-            </h1>
-            <p className="max-w-2xl text-sm leading-relaxed text-foreground/65 sm:text-base">
-              {t.services.pricing}
-            </p>
+            <div className="space-y-4">
+              <h1 className="text-4xl font-semibold leading-tight text-foreground sm:text-5xl">
+                {t.services.subtitle}
+              </h1>
+              <p className="text-sm leading-relaxed text-foreground/65 sm:text-base">
+                {t.services.pricing}
+              </p>
+            </div>
           </ScrollReveal>
 
-          {heroHighlights.length > 0 && (
-            <ScrollReveal variant="default" delay={120}>
-              <div className="grid gap-3 sm:grid-cols-3">
-                {heroHighlights.map((item, index) => (
-                  <div
-                    key={index}
-                    className="flex items-start gap-2 rounded-xl border border-foreground/10 bg-background/70 p-3 text-sm text-foreground/70 shadow-sm backdrop-blur"
-                  >
-                    <CheckCircle2 className="mt-0.5 h-4 w-4 text-primary" />
-                    <span className="leading-snug">{item}</span>
-                  </div>
-                ))}
-              </div>
-            </ScrollReveal>
-          )}
+          <ScrollReveal variant="default" delay={120} className="md:w-[min(18rem,45%)]">
+            <div className="flex flex-col gap-4">
+              {heroHighlights.length > 0 && (
+                <div className="flex flex-wrap gap-2">
+                  {heroHighlights.map((item, index) => (
+                    <span
+                      key={index}
+                      className="inline-flex items-center gap-2 rounded-full border border-foreground/15 px-3 py-1 text-xs font-medium text-foreground/65"
+                    >
+                      <CheckCircle2 className="h-3.5 w-3.5 text-foreground/50" />
+                      {item}
+                    </span>
+                  ))}
+                </div>
+              )}
 
-          <ScrollReveal variant="default" delay={160}>
-            <div>
-              <Link to="/contact">
+              <Link to="/contact" className="w-full">
                 <IconButton
-                  className="w-full bg-primary text-primary-foreground shadow-lg shadow-primary/20 hover:bg-primary/90 sm:w-auto"
+                  variant="outline"
+                  className="w-full border-foreground/20 text-sm hover:border-foreground/30 hover:bg-foreground/5"
                   icon={<ArrowRightIcon />}
                   label={t.services.getStarted || "Get Started"}
                 />
@@ -173,67 +161,54 @@ const Services = () => {
           return (
             <ScrollReveal key={service.key} variant="default" delay={index * 120}>
               <motion.div
-                whileHover={{ translateY: -8 }}
-                transition={{ type: "spring", stiffness: 240, damping: 22 }}
+                whileHover={{ translateY: -6 }}
+                transition={{ type: "spring", stiffness: 240, damping: 24 }}
                 className={cn(
-                  "group relative flex h-full flex-col overflow-hidden rounded-3xl border border-foreground/10 bg-background/80 p-6 sm:p-7 transition-all duration-300 backdrop-blur",
-                  style.shadow
+                  "group flex h-full flex-col gap-6 rounded-3xl border border-foreground/10 bg-background/80 p-6 transition-all duration-200 hover:shadow-lg",
+                  style.border
                 )}
               >
-                <div className={cn("pointer-events-none absolute inset-0 rounded-3xl bg-gradient-to-br opacity-70", style.accent)} />
-                <div
-                  className={cn(
-                    "pointer-events-none absolute inset-0 rounded-3xl bg-gradient-to-br opacity-0 transition-opacity duration-300 group-hover:opacity-100",
-                    style.hoverAccent
+                <div className="flex items-start justify-between gap-4">
+                  <div className={cn("flex h-12 w-12 items-center justify-center rounded-2xl", style.iconBg)}>
+                    <service.icon className={cn("h-6 w-6", style.iconColor)} />
+                  </div>
+                  {badgeLabel && (
+                    <Badge className={cn("border px-3 py-1 text-[11px] font-medium uppercase tracking-[0.2em]", style.badge)}>
+                      {badgeLabel}
+                    </Badge>
                   )}
-                />
+                </div>
 
-                <div className="relative z-10 flex h-full flex-col gap-6">
-                  <div className="flex items-start justify-between gap-4">
-                    <div className={cn("rounded-2xl p-3 transition-colors duration-300", style.iconBg)}>
-                      <service.icon className={cn("h-6 w-6 transition-colors duration-300", style.iconColor)} />
-                    </div>
-                    {badgeLabel && (
-                      <Badge className={cn("border text-xs font-medium uppercase tracking-[0.2em] backdrop-blur", style.badge)}>
-                        {badgeLabel}
-                      </Badge>
-                    )}
-                  </div>
+                <div className="space-y-3">
+                  <h3 className="text-xl font-semibold text-foreground">{serviceContent.title}</h3>
+                  <p className="text-sm leading-relaxed text-foreground/70">{serviceContent.description}</p>
+                </div>
 
-                  <div className="space-y-3">
-                    <h3 className="text-xl font-semibold text-foreground">{serviceContent.title}</h3>
-                    <p className="text-sm leading-relaxed text-foreground/70">{serviceContent.description}</p>
-                  </div>
+                <div className="space-y-1">
+                  <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-foreground/50">
+                    {t.services.startingFrom}
+                  </span>
+                  <span className="text-lg font-semibold text-foreground">{serviceContent.price}</span>
+                </div>
 
-                  <div className="grid flex-1 grid-cols-1 gap-3 text-sm sm:grid-cols-2">
-                    {serviceContent.features.map((feature, featureIndex) => (
-                      <div
-                        key={featureIndex}
-                        className="flex items-start gap-2 rounded-2xl border border-transparent bg-foreground/[0.02] p-3 transition-all duration-300 group-hover:border-foreground/10 group-hover:bg-foreground/[0.04]"
-                      >
-                        <CheckCircle2 className="mt-0.5 h-4 w-4 flex-shrink-0 text-primary/80" />
-                        <span className="leading-snug text-foreground/70 group-hover:text-foreground/80">{feature}</span>
-                      </div>
-                    ))}
-                  </div>
+                <ul className="space-y-2 text-sm text-foreground/70">
+                  {serviceContent.features.map((feature, featureIndex) => (
+                    <li key={featureIndex} className="flex items-start gap-2">
+                      <CheckCircle2 className="mt-0.5 h-4 w-4 flex-shrink-0 text-foreground/45" />
+                      <span className="leading-snug">{feature}</span>
+                    </li>
+                  ))}
+                </ul>
 
-                  <div className="mt-2 space-y-4">
-                    <div className="flex flex-col gap-1 rounded-2xl border border-dashed border-foreground/15 bg-background/80 p-4">
-                      <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-foreground/50">
-                        {t.services.startingFrom}
-                      </span>
-                      <span className="text-2xl font-semibold text-foreground">{serviceContent.price}</span>
-                    </div>
-
-                    <Link to={getServiceContactUrl(service.key)} className="block">
-                      <IconButton
-                        variant="outline"
-                        className="w-full justify-between border-foreground/20 bg-background/80 text-sm hover:border-primary/40 hover:bg-primary/10"
-                        label={t.services.getStarted || "Get Started"}
-                        icon={<ArrowRightIcon />}
-                      />
-                    </Link>
-                  </div>
+                <div className="mt-auto pt-2">
+                  <Link to={getServiceContactUrl(service.key)} className="block">
+                    <IconButton
+                      variant="outline"
+                      className="w-full justify-between border-foreground/20 text-sm hover:border-foreground/30 hover:bg-foreground/5"
+                      label={t.services.getStarted || "Get Started"}
+                      icon={<ArrowRightIcon />}
+                    />
+                  </Link>
                 </div>
               </motion.div>
             </ScrollReveal>
@@ -242,11 +217,8 @@ const Services = () => {
       </div>
 
       <ScrollReveal variant="default">
-        <div className="relative overflow-hidden rounded-[2rem] border border-primary/20 bg-gradient-to-br from-primary/15 via-primary/5 to-background px-6 py-10 sm:px-10 sm:py-12">
-          <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(255,255,255,0.22),transparent_55%)]" />
-          <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_bottom_left,rgba(255,255,255,0.18),transparent_55%)]" />
-
-          <div className="relative z-10 grid gap-8 md:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)] md:items-center">
+        <div className="rounded-[2rem] border border-foreground/10 bg-background/80 px-6 py-10 sm:px-10 sm:py-12">
+          <div className="grid gap-6 md:grid-cols-[minmax(0,1.6fr)_minmax(0,1fr)] md:items-center">
             <div className="space-y-4">
               <h2 className="text-2xl font-semibold text-foreground sm:text-3xl">{t.services.customRequirements.title}</h2>
               <p className="text-sm leading-relaxed text-foreground/70 sm:text-base">
@@ -254,14 +226,15 @@ const Services = () => {
               </p>
             </div>
 
-            <div className="flex flex-col gap-4 rounded-2xl border border-white/20 bg-background/80 p-6 shadow-lg shadow-primary/10 backdrop-blur">
-              <p className="text-sm text-foreground/65">{t.services.pricing}</p>
+            <div className="flex flex-col gap-4 rounded-2xl border border-foreground/10 bg-background/70 p-6">
+              <p className="text-sm text-foreground/65">{t.services.customRequirements.note}</p>
               <Link
                 to="/contact?subject=Custom%20Development%20Requirements&message=Hi%20Yanis%2C%0A%0AI%20have%20specific%20requirements%20that%20don%27t%20fit%20standard%20service%20categories.%20I%27d%20like%20to%20discuss%20a%20custom%20solution.%0A%0AProject%20details%3A%0A-%20%0A-%20%0A-%20%0A%0ALooking%20forward%20to%20discussing%20this%20further%21"
                 className="w-full"
               >
                 <IconButton
-                  className="w-full bg-primary text-primary-foreground shadow-lg shadow-primary/20 hover:bg-primary/90"
+                  variant="outline"
+                  className="w-full border-foreground/20 text-sm hover:border-foreground/30 hover:bg-foreground/5"
                   icon={<ArrowRightIcon />}
                   label={t.services.customRequirements.button}
                 />

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -8,11 +8,9 @@
 
 import { Code2, Blocks, Database, Lightbulb, ArrowRightIcon, CheckCircle2, type LucideIcon } from "lucide-react";
 import { Link } from "react-router-dom";
-import { motion } from "motion/react";
 import { useLanguage } from "@/lib/language-provider";
 import { translations, type Translation } from "@/lib/translations";
 import { Helmet } from "react-helmet-async";
-import { IconButton } from "@/components/ui/custom/IconButton";
 import ScrollReveal from "@/components/ScrollReveal";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
@@ -41,35 +39,35 @@ const servicesList: Array<{ key: ServiceKey; icon: LucideIcon }> = [
 const serviceStyles: Record<
   ServiceKey,
   {
-    border: string;
+    accent: string;
     iconBg: string;
     iconColor: string;
     badge: string;
   }
 > = {
   fullstack: {
-    border: "hover:border-sky-400/40",
-    iconBg: "bg-sky-500/10",
-    iconColor: "text-sky-400",
-    badge: "border-sky-400/30 bg-sky-400/10 text-sky-400",
+    accent: "from-sky-500/25 via-sky-500/10 to-transparent",
+    iconBg: "bg-sky-500/15",
+    iconColor: "text-sky-200",
+    badge: "border-sky-400/40 bg-sky-500/10 text-sky-100",
   },
   frontend: {
-    border: "hover:border-rose-400/40",
-    iconBg: "bg-rose-500/10",
-    iconColor: "text-rose-400",
-    badge: "border-rose-400/30 bg-rose-400/10 text-rose-400",
+    accent: "from-rose-500/25 via-rose-500/10 to-transparent",
+    iconBg: "bg-rose-500/15",
+    iconColor: "text-rose-200",
+    badge: "border-rose-400/35 bg-rose-500/10 text-rose-100",
   },
   backend: {
-    border: "hover:border-violet-400/40",
-    iconBg: "bg-violet-500/10",
-    iconColor: "text-violet-400",
-    badge: "border-violet-400/30 bg-violet-400/10 text-violet-400",
+    accent: "from-violet-500/25 via-violet-500/10 to-transparent",
+    iconBg: "bg-violet-500/15",
+    iconColor: "text-violet-200",
+    badge: "border-violet-400/35 bg-violet-500/10 text-violet-100",
   },
   consulting: {
-    border: "hover:border-amber-400/40",
-    iconBg: "bg-amber-500/10",
-    iconColor: "text-amber-400",
-    badge: "border-amber-400/30 bg-amber-400/10 text-amber-400",
+    accent: "from-amber-500/25 via-amber-500/10 to-transparent",
+    iconBg: "bg-amber-500/15",
+    iconColor: "text-amber-200",
+    badge: "border-amber-400/35 bg-amber-500/10 text-amber-100",
   },
 };
 
@@ -107,10 +105,18 @@ const Services = () => {
         <meta name="description" content={t.seo.services.description} />
       </Helmet>
 
-      <section className="rounded-[2rem] border border-foreground/10 bg-background/80 px-6 py-10 sm:px-10 sm:py-12">
-        <div className="flex flex-col gap-8 md:flex-row md:items-end md:justify-between">
+      <section className="relative overflow-hidden rounded-[2rem] border border-foreground/10 bg-background/95 px-6 py-10 sm:px-10 sm:py-12">
+        <div
+          aria-hidden
+          className="pointer-events-none absolute -left-24 top-[-6rem] h-52 w-52 rounded-full bg-[radial-gradient(circle_at_center,rgba(56,189,248,0.25),transparent_70%)]"
+        />
+        <div
+          aria-hidden
+          className="pointer-events-none absolute -right-16 bottom-[-8rem] h-64 w-64 rounded-full bg-[radial-gradient(circle_at_center,rgba(248,113,113,0.22),transparent_70%)]"
+        />
+        <div className="relative flex flex-col gap-8 md:flex-row md:items-end md:justify-between">
           <ScrollReveal variant="pageTitle" className="space-y-6 md:max-w-2xl">
-            <div className="inline-flex w-fit items-center gap-2 rounded-full border border-foreground/20 px-3 py-1 text-xs font-medium uppercase tracking-[0.28em] text-foreground/60">
+            <div className="inline-flex w-fit items-center gap-2 rounded-full border border-foreground/15 bg-foreground/[0.04] px-3 py-1 text-[11px] font-medium uppercase tracking-[0.28em] text-foreground/60">
               {t.services.title}
             </div>
             <div className="space-y-4">
@@ -123,29 +129,28 @@ const Services = () => {
             </div>
           </ScrollReveal>
 
-          <ScrollReveal variant="default" delay={120} className="md:w-[min(18rem,45%)]">
-            <div className="flex flex-col gap-4">
+          <ScrollReveal variant="default" delay={120} className="md:w-[min(20rem,45%)]">
+            <div className="flex flex-col gap-5">
               {heroHighlights.length > 0 && (
-                <div className="flex flex-wrap gap-2">
+                <div className="grid gap-3 sm:grid-cols-2">
                   {heroHighlights.map((item, index) => (
-                    <span
+                    <div
                       key={index}
-                      className="inline-flex items-center gap-2 rounded-full border border-foreground/15 px-3 py-1 text-xs font-medium text-foreground/65"
+                      className="flex items-center gap-2 rounded-2xl border border-foreground/12 bg-foreground/[0.05] px-4 py-3 text-sm text-foreground/70 backdrop-blur-sm"
                     >
-                      <CheckCircle2 className="h-3.5 w-3.5 text-foreground/50" />
-                      {item}
-                    </span>
+                      <CheckCircle2 className="h-4 w-4 text-foreground/50" />
+                      <span>{item}</span>
+                    </div>
                   ))}
                 </div>
               )}
 
-              <Link to="/contact" className="w-full">
-                <IconButton
-                  variant="outline"
-                  className="w-full border-foreground/20 text-sm hover:border-foreground/30 hover:bg-foreground/5"
-                  icon={<ArrowRightIcon />}
-                  label={t.services.getStarted || "Get Started"}
-                />
+              <Link
+                to="/contact"
+                className="group flex w-full items-center justify-between rounded-2xl border border-foreground/12 bg-foreground/[0.04] px-4 py-3 text-sm font-medium text-foreground transition-colors hover:border-foreground/18 hover:bg-foreground/[0.07]"
+              >
+                <span>{t.services.getStarted || "Get Started"}</span>
+                <ArrowRightIcon className="h-4 w-4 transition-transform duration-200 group-hover:translate-x-1" />
               </Link>
             </div>
           </ScrollReveal>
@@ -160,65 +165,81 @@ const Services = () => {
 
           return (
             <ScrollReveal key={service.key} variant="default" delay={index * 120}>
-              <motion.div
-                whileHover={{ translateY: -6 }}
-                transition={{ type: "spring", stiffness: 240, damping: 24 }}
-                className={cn(
-                  "group flex h-full flex-col gap-6 rounded-3xl border border-foreground/10 bg-background/80 p-6 transition-all duration-200 hover:shadow-lg",
-                  style.border
-                )}
+              <div
+                className="group relative flex h-full flex-col gap-6 overflow-hidden rounded-3xl border border-foreground/10 bg-background/95 p-6 shadow-[0_18px_48px_-32px_rgba(15,23,42,0.55)] transition-colors hover:border-foreground/18"
               >
-                <div className="flex items-start justify-between gap-4">
+                <div
+                  aria-hidden
+                  className={cn(
+                    "pointer-events-none absolute inset-x-6 top-6 h-28 rounded-[2rem] bg-gradient-to-br opacity-80",
+                    style.accent
+                  )}
+                />
+
+                <div className="relative flex items-start justify-between gap-4">
                   <div className={cn("flex h-12 w-12 items-center justify-center rounded-2xl", style.iconBg)}>
                     <service.icon className={cn("h-6 w-6", style.iconColor)} />
                   </div>
                   {badgeLabel && (
-                    <Badge className={cn("border px-3 py-1 text-[11px] font-medium uppercase tracking-[0.2em]", style.badge)}>
+                    <Badge
+                      variant="outline"
+                      className={cn(
+                        "rounded-full border border-foreground/12 bg-foreground/[0.04] px-3 py-1 text-[11px] font-medium uppercase tracking-[0.22em] text-foreground/60 backdrop-blur-sm",
+                        style.badge
+                      )}
+                    >
                       {badgeLabel}
                     </Badge>
                   )}
                 </div>
 
-                <div className="space-y-3">
+                <div className="relative space-y-3">
                   <h3 className="text-xl font-semibold text-foreground">{serviceContent.title}</h3>
                   <p className="text-sm leading-relaxed text-foreground/70">{serviceContent.description}</p>
                 </div>
 
-                <div className="space-y-1">
-                  <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-foreground/50">
+                <div className="relative flex items-center justify-between rounded-2xl border border-foreground/8 bg-foreground/[0.03] px-4 py-3">
+                  <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-foreground/55">
                     {t.services.startingFrom}
                   </span>
-                  <span className="text-lg font-semibold text-foreground">{serviceContent.price}</span>
+                  <span className="text-base font-semibold text-foreground">{serviceContent.price}</span>
                 </div>
 
-                <ul className="space-y-2 text-sm text-foreground/70">
-                  {serviceContent.features.map((feature, featureIndex) => (
-                    <li key={featureIndex} className="flex items-start gap-2">
-                      <CheckCircle2 className="mt-0.5 h-4 w-4 flex-shrink-0 text-foreground/45" />
-                      <span className="leading-snug">{feature}</span>
-                    </li>
-                  ))}
-                </ul>
+                {serviceContent.features.length > 0 && (
+                  <div className="relative flex flex-wrap gap-2">
+                    {serviceContent.features.map((feature, featureIndex) => (
+                      <span
+                        key={featureIndex}
+                        className="rounded-full border border-foreground/12 bg-foreground/[0.04] px-3 py-1 text-xs font-medium text-foreground/70"
+                      >
+                        {feature}
+                      </span>
+                    ))}
+                  </div>
+                )}
 
-                <div className="mt-auto pt-2">
-                  <Link to={getServiceContactUrl(service.key)} className="block">
-                    <IconButton
-                      variant="outline"
-                      className="w-full justify-between border-foreground/20 text-sm hover:border-foreground/30 hover:bg-foreground/5"
-                      label={t.services.getStarted || "Get Started"}
-                      icon={<ArrowRightIcon />}
-                    />
+                <div className="relative mt-auto pt-2">
+                  <Link
+                    to={getServiceContactUrl(service.key)}
+                    className="group flex w-full items-center justify-between rounded-2xl border border-foreground/12 bg-transparent px-4 py-3 text-sm font-medium text-foreground transition-colors hover:border-foreground/18 hover:bg-foreground/[0.06]"
+                  >
+                    <span>{t.services.getStarted || "Get Started"}</span>
+                    <ArrowRightIcon className="h-4 w-4 transition-transform duration-200 group-hover:translate-x-1" />
                   </Link>
                 </div>
-              </motion.div>
+              </div>
             </ScrollReveal>
           );
         })}
       </div>
 
       <ScrollReveal variant="default">
-        <div className="rounded-[2rem] border border-foreground/10 bg-background/80 px-6 py-10 sm:px-10 sm:py-12">
-          <div className="grid gap-6 md:grid-cols-[minmax(0,1.6fr)_minmax(0,1fr)] md:items-center">
+        <div className="relative overflow-hidden rounded-[2rem] border border-foreground/10 bg-background/95 px-6 py-10 sm:px-10 sm:py-12">
+          <div
+            aria-hidden
+            className="pointer-events-none absolute right-10 top-6 h-40 w-40 rounded-full bg-[radial-gradient(circle_at_center,rgba(217,249,157,0.2),transparent_70%)]"
+          />
+          <div className="relative grid gap-6 md:grid-cols-[minmax(0,1.6fr)_minmax(0,1fr)] md:items-center">
             <div className="space-y-4">
               <h2 className="text-2xl font-semibold text-foreground sm:text-3xl">{t.services.customRequirements.title}</h2>
               <p className="text-sm leading-relaxed text-foreground/70 sm:text-base">
@@ -226,18 +247,14 @@ const Services = () => {
               </p>
             </div>
 
-            <div className="flex flex-col gap-4 rounded-2xl border border-foreground/10 bg-background/70 p-6">
+            <div className="flex flex-col gap-4 rounded-2xl border border-foreground/10 bg-foreground/[0.04] p-6 backdrop-blur-sm">
               <p className="text-sm text-foreground/65">{t.services.customRequirements.note}</p>
               <Link
                 to="/contact?subject=Custom%20Development%20Requirements&message=Hi%20Yanis%2C%0A%0AI%20have%20specific%20requirements%20that%20don%27t%20fit%20standard%20service%20categories.%20I%27d%20like%20to%20discuss%20a%20custom%20solution.%0A%0AProject%20details%3A%0A-%20%0A-%20%0A-%20%0A%0ALooking%20forward%20to%20discussing%20this%20further%21"
-                className="w-full"
+                className="group flex w-full items-center justify-between rounded-2xl border border-foreground/12 bg-transparent px-4 py-3 text-sm font-medium text-foreground transition-colors hover:border-foreground/18 hover:bg-foreground/[0.06]"
               >
-                <IconButton
-                  variant="outline"
-                  className="w-full border-foreground/20 text-sm hover:border-foreground/30 hover:bg-foreground/5"
-                  icon={<ArrowRightIcon />}
-                  label={t.services.customRequirements.button}
-                />
+                <span>{t.services.customRequirements.button}</span>
+                <ArrowRightIcon className="h-4 w-4 transition-transform duration-200 group-hover:translate-x-1" />
               </Link>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- surface service pricing directly on each card with a starting-rate label and refreshed layout
- add localized starting-from labels and price strings for every supported language

## Testing
- npm run lint *(fails: existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d181f5fb14832d8ebdb376ea10f722