### PR TITLE
feat: add silent motion primitives to ui components

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,8 +1,10 @@
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
+import { motion, type MotionProps } from "motion/react";
 
 import { cn } from "@/lib/utils";
+import { silentMotion } from "./silent-motion";
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
@@ -35,17 +37,48 @@ const buttonVariants = cva(
 
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
-    VariantProps<typeof buttonVariants> {
+    VariantProps<typeof buttonVariants>,
+    MotionProps {
   asChild?: boolean;
 }
 
-const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild = false, ...props }, ref) => {
-    const Comp = asChild ? Slot : "button";
+const MotionSlot = motion(
+  React.forwardRef<
+    HTMLElement,
+    React.ComponentPropsWithoutRef<typeof Slot> & MotionProps
+  >(function MotionSlot({ children, ...props }, forwardedRef) {
     return (
-      <Comp
+      <Slot ref={forwardedRef as never} {...props}>
+        {children}
+      </Slot>
+    );
+  }),
+);
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  (
+    { className, variant, size, asChild = false, type, ...props },
+    ref,
+  ) => {
+    const motionProps = silentMotion({ depth: 3.6 });
+
+    if (asChild) {
+      return (
+        <MotionSlot
+          {...motionProps}
+          className={cn(buttonVariants({ variant, size, className }))}
+          {...props}
+          ref={ref as never}
+        />
+      );
+    }
+
+    return (
+      <motion.button
+        {...motionProps}
         className={cn(buttonVariants({ variant, size, className }))}
         ref={ref}
+        type={type ?? "button"}
         {...props}
       />
     );

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,20 +1,24 @@
 import * as React from "react";
+import { motion, type MotionProps } from "motion/react";
 
 import { cn } from "@/lib/utils";
+import { silentMotion } from "./silent-motion";
 
-const Card = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn(
-      "rounded-lg border bg-card text-card-foreground shadow-sm",
-      className,
-    )}
-    {...props}
-  />
-));
+type CardProps = React.ComponentPropsWithoutRef<typeof motion.div>;
+
+const Card = React.forwardRef<HTMLDivElement, CardProps>(
+  ({ className, ...props }, ref) => (
+    <motion.div
+      {...silentMotion({ depth: 2.4, press: false })}
+      ref={ref}
+      className={cn(
+        "rounded-lg border bg-card text-card-foreground shadow-sm",
+        className,
+      )}
+      {...(props as MotionProps)}
+    />
+  ),
+);
 Card.displayName = "Card";
 
 const CardHeader = React.forwardRef<

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,6 +1,8 @@
 import * as React from "react";
 import { cva, type VariantProps } from "class-variance-authority";
+import { motion, type MotionProps } from "motion/react";
 import { cn } from "@/lib/utils";
+import { silentMotion } from "./silent-motion";
 
 const inputVariants = cva(
   "flex w-full px-3 py-2 text-base md:text-sm ring-offset-background placeholder:text-muted-foreground caret-[hsl(var(--ring))] disabled:cursor-not-allowed disabled:opacity-50 file:border-0 file:bg-transparent file:text-sm file:font-medium transition-[color,background-color,border-color,box-shadow,transform] duration-200 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 placeholder:transition-opacity placeholder:opacity-70 focus-visible:placeholder:opacity-50 selection:bg-ring/20",
@@ -46,14 +48,16 @@ const inputVariants = cva(
 
 export interface InputProps
   extends React.InputHTMLAttributes<HTMLInputElement>,
-    VariantProps<typeof inputVariants> {}
+    VariantProps<typeof inputVariants>,
+    MotionProps {}
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
   (
     { className, type, inputSize, appearance, radius, invalid, ...props },
     ref,
   ) => (
-    <input
+    <motion.input
+      {...silentMotion({ depth: 2.2, press: false })}
       type={type}
       className={cn(
         inputVariants({ inputSize, appearance, radius, invalid }),

--- a/src/components/ui/silent-motion.ts
+++ b/src/components/ui/silent-motion.ts
@@ -1,0 +1,122 @@
+import type { MotionProps } from "motion/react";
+
+type SilentMotionOptions = {
+  depth?: number;
+  hover?: boolean;
+  press?: boolean;
+  focus?: boolean;
+  reveal?: boolean;
+};
+
+const baseTransition = {
+  type: "spring" as const,
+  bounce: 0.18,
+  duration: 0.45,
+  mass: 0.65,
+};
+
+const hoverTransition = {
+  type: "spring" as const,
+  stiffness: 240,
+  damping: 22,
+  mass: 0.7,
+};
+
+const pressTransition = {
+  type: "spring" as const,
+  stiffness: 400,
+  damping: 30,
+  mass: 0.6,
+};
+
+const focusTransition = {
+  type: "spring" as const,
+  stiffness: 280,
+  damping: 26,
+  mass: 0.65,
+};
+
+const mergeMotion = (
+  base: MotionProps,
+  overrides?: MotionProps,
+): MotionProps => {
+  if (!overrides) return base;
+
+  return {
+    ...base,
+    ...overrides,
+    animate: {
+      ...(typeof base.animate === "object" ? base.animate : {}),
+      ...(typeof overrides.animate === "object" ? overrides.animate : {}),
+    },
+    initial: {
+      ...(typeof base.initial === "object" ? base.initial : {}),
+      ...(typeof overrides.initial === "object" ? overrides.initial : {}),
+    },
+    whileHover: {
+      ...(typeof base.whileHover === "object" ? base.whileHover : {}),
+      ...(typeof overrides.whileHover === "object" ? overrides.whileHover : {}),
+    },
+    whileTap: {
+      ...(typeof base.whileTap === "object" ? base.whileTap : {}),
+      ...(typeof overrides.whileTap === "object" ? overrides.whileTap : {}),
+    },
+    whileFocus: {
+      ...(typeof base.whileFocus === "object" ? base.whileFocus : {}),
+      ...(typeof overrides.whileFocus === "object" ? overrides.whileFocus : {}),
+    },
+  } satisfies MotionProps;
+};
+
+export const silentMotion = (
+  options: SilentMotionOptions = {},
+  overrides?: MotionProps,
+): MotionProps => {
+  const { depth = 3, hover = true, press = true, focus = true, reveal = true } = options;
+
+  const revealDistance = depth * 0.6;
+  const motion: MotionProps = {
+    animate: {
+      y: 0,
+      scale: 1,
+      opacity: 1,
+      transition: baseTransition,
+    },
+  };
+
+  if (reveal) {
+    motion.initial = {
+      y: revealDistance,
+      scale: 0.99,
+      opacity: 0.92,
+    };
+  }
+
+  if (hover) {
+    motion.whileHover = {
+      y: -depth * 0.4,
+      scale: 1 + depth * 0.003,
+      transition: hoverTransition,
+    };
+  }
+
+  if (press) {
+    motion.whileTap = {
+      y: depth * 0.6,
+      scale: 1 - depth * 0.005,
+      transition: pressTransition,
+    };
+  }
+
+  if (focus) {
+    motion.whileFocus = {
+      y: -depth * 0.2,
+      scale: 1 + depth * 0.002,
+      transition: focusTransition,
+    };
+  }
+
+  return mergeMotion(motion, overrides);
+};
+
+export type { SilentMotionOptions };

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,6 +1,8 @@
 import * as React from "react";
 import { cva, type VariantProps } from "class-variance-authority";
+import { motion, type MotionProps } from "motion/react";
 import { cn } from "@/lib/utils";
+import { silentMotion } from "./silent-motion";
 
 const textareaVariants = cva(
   "flex w-full px-3 py-2 text-base md:text-sm ring-offset-background placeholder:text-muted-foreground caret-[hsl(var(--ring))] disabled:cursor-not-allowed disabled:opacity-50 transition-[color,background-color,border-color,box-shadow,transform] duration-200 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 placeholder:transition-opacity placeholder:opacity-70 focus-visible:placeholder:opacity-50 selection:bg-ring/20",
@@ -51,14 +53,16 @@ const textareaVariants = cva(
 
 export interface TextareaProps
   extends React.TextareaHTMLAttributes<HTMLTextAreaElement>,
-    VariantProps<typeof textareaVariants> {}
+    VariantProps<typeof textareaVariants>,
+    MotionProps {}
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   (
     { className, resizable, minHeight, appearance, radius, invalid, ...props },
     ref,
   ) => (
-    <textarea
+    <motion.textarea
+      {...silentMotion({ depth: 2.2, press: false })}
       className={cn(
         textareaVariants({ resizable, minHeight, appearance, radius, invalid }),
         className,


### PR DESCRIPTION
## Summary
- add a reusable `silentMotion` helper for motion/react driven depth animations
- apply the silent motion experience to Button, Card, Input, and Textarea primitives

## Testing
- npm run lint *(fails: pre-existing lint violations)*

------
https://chatgpt.com/codex/tasks/task_e_690a42b837ac832dbb205b92022e6a1b

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a reusable motion helper and applies subtle motion animations to core UI components.
> 
> - **Utilities**
>   - Add `src/components/ui/silent-motion.ts`: `silentMotion(options, overrides)` helper with spring transitions and `MotionProps` merging.
> - **Components**
>   - **`Button`**: Wrap with `motion.button`; add `MotionProps` to `ButtonProps`; introduce `MotionSlot` for `asChild`; apply `silentMotion({ depth: 3.6 })`; default `type` to `"button"`.
>   - **`Card`**: Convert root to `motion.div`; use `silentMotion({ depth: 2.4, press: false })`; update props to `ComponentPropsWithoutRef<typeof motion.div>`.
>   - **`Input`**: Convert to `motion.input`; extend props with `MotionProps`; apply `silentMotion({ depth: 2.2, press: false })`.
>   - **`Textarea`**: Convert to `motion.textarea`; extend props with `MotionProps`; apply `silentMotion({ depth: 2.2, press: false })`.)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7c74f2f3f286e37b5dad9eae77c42534dbfad5c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->