### PR TITLE
Add silent motion interactions to core UI primitives

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,8 +1,11 @@
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
+import { motion } from "framer-motion";
 
 import { cn } from "@/lib/utils";
+
+import { useSilentMotion } from "./silent-motion";
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
@@ -37,15 +40,45 @@ export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
   asChild?: boolean;
+  disableMotion?: boolean;
 }
 
+const MotionButton = motion.button;
+
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild = false, ...props }, ref) => {
-    const Comp = asChild ? Slot : "button";
+  (
+    {
+      className,
+      variant,
+      size,
+      asChild = false,
+      disableMotion,
+      disabled,
+      ...props
+    },
+    ref,
+  ) => {
+    const motionProps = useSilentMotion({
+      disabled: disableMotion || disabled || props["aria-disabled"] === true,
+    });
+
+    if (asChild) {
+      return (
+        <Slot
+          ref={ref}
+          className={cn(buttonVariants({ variant, size, className }))}
+          aria-disabled={disabled || props["aria-disabled"]}
+          {...props}
+        />
+      );
+    }
+
     return (
-      <Comp
-        className={cn(buttonVariants({ variant, size, className }))}
+      <MotionButton
         ref={ref}
+        className={cn(buttonVariants({ variant, size, className }))}
+        disabled={disabled}
+        {...motionProps}
         {...props}
       />
     );

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,20 +1,40 @@
 import * as React from "react";
+import { motion } from "framer-motion";
 
 import { cn } from "@/lib/utils";
 
-const Card = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn(
-      "rounded-lg border bg-card text-card-foreground shadow-sm",
-      className,
-    )}
-    {...props}
-  />
-));
+import { useSilentMotion, type MotionIntensity } from "./silent-motion";
+
+type CardProps = React.HTMLAttributes<HTMLDivElement> & {
+  disableMotion?: boolean;
+  motionIntensity?: MotionIntensity;
+};
+
+const MotionCard = motion.div;
+
+const Card = React.forwardRef<HTMLDivElement, CardProps>(
+  (
+    { className, disableMotion, motionIntensity = "subtle", ...props },
+    ref,
+  ) => {
+    const motionProps = useSilentMotion({
+      disabled: disableMotion,
+      intensity: motionIntensity,
+    });
+
+    return (
+      <MotionCard
+        ref={ref}
+        className={cn(
+          "rounded-lg border bg-card text-card-foreground shadow-sm",
+          className,
+        )}
+        {...motionProps}
+        {...props}
+      />
+    );
+  },
+);
 Card.displayName = "Card";
 
 const CardHeader = React.forwardRef<

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,6 +1,10 @@
 import * as React from "react";
 import { cva, type VariantProps } from "class-variance-authority";
+import { motion } from "framer-motion";
+
 import { cn } from "@/lib/utils";
+
+import { useSilentMotion, type MotionIntensity } from "./silent-motion";
 
 const inputVariants = cva(
   "flex w-full px-3 py-2 text-base md:text-sm ring-offset-background placeholder:text-muted-foreground caret-[hsl(var(--ring))] disabled:cursor-not-allowed disabled:opacity-50 file:border-0 file:bg-transparent file:text-sm file:font-medium transition-[color,background-color,border-color,box-shadow,transform] duration-200 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 placeholder:transition-opacity placeholder:opacity-70 focus-visible:placeholder:opacity-50 selection:bg-ring/20",
@@ -46,23 +50,46 @@ const inputVariants = cva(
 
 export interface InputProps
   extends React.InputHTMLAttributes<HTMLInputElement>,
-    VariantProps<typeof inputVariants> {}
+    VariantProps<typeof inputVariants> {
+  disableMotion?: boolean;
+  motionIntensity?: MotionIntensity;
+}
+
+const MotionInput = motion.input;
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
   (
-    { className, type, inputSize, appearance, radius, invalid, ...props },
+    {
+      className,
+      type,
+      inputSize,
+      appearance,
+      radius,
+      invalid,
+      disableMotion,
+      motionIntensity = "subtle",
+      ...props
+    },
     ref,
-  ) => (
-    <input
-      type={type}
-      className={cn(
-        inputVariants({ inputSize, appearance, radius, invalid }),
-        className,
-      )}
-      ref={ref}
-      {...props}
-    />
-  ),
+  ) => {
+    const motionProps = useSilentMotion({
+      disabled: disableMotion || props.disabled,
+      intensity: motionIntensity,
+    });
+
+    return (
+      <MotionInput
+        type={type}
+        className={cn(
+          inputVariants({ inputSize, appearance, radius, invalid }),
+          className,
+        )}
+        ref={ref}
+        {...motionProps}
+        {...props}
+      />
+    );
+  },
 );
 Input.displayName = "Input";
 

--- a/src/components/ui/silent-motion.ts
+++ b/src/components/ui/silent-motion.ts
@@ -1,0 +1,63 @@
+import * as React from "react";
+import type { MotionProps } from "framer-motion";
+import { useReducedMotion } from "framer-motion";
+
+type MotionIntensity = "subtle" | "base" | "bold";
+
+type UseSilentMotionOptions = {
+  disabled?: boolean;
+  intensity?: MotionIntensity;
+  focus?: boolean;
+};
+
+const intensityMap: Record<MotionIntensity, { lift: number; scale: number }> = {
+  subtle: { lift: 1, scale: 0.01 },
+  base: { lift: 2, scale: 0.015 },
+  bold: { lift: 3, scale: 0.02 },
+};
+
+const transition: MotionProps["transition"] = {
+  type: "spring",
+  stiffness: 520,
+  damping: 32,
+  mass: 0.45,
+};
+
+export const useSilentMotion = (
+  { disabled, intensity = "base", focus = true }: UseSilentMotionOptions = {},
+): MotionProps => {
+  const prefersReducedMotion = useReducedMotion();
+
+  return React.useMemo(() => {
+    if (disabled || prefersReducedMotion) {
+      return { initial: false };
+    }
+
+    const { lift, scale } = intensityMap[intensity];
+
+    const hoverState = {
+      y: -lift,
+      scale: 1 + scale,
+    };
+
+    const tapState = {
+      y: lift,
+      scale: 1 - scale * 0.6,
+    };
+
+    const baseState: MotionProps = {
+      initial: false,
+      transition,
+      whileHover: hoverState,
+      whileTap: tapState,
+    };
+
+    if (focus) {
+      baseState.whileFocus = hoverState;
+    }
+
+    return baseState;
+  }, [disabled, focus, intensity, prefersReducedMotion]);
+};
+
+export type { MotionIntensity, UseSilentMotionOptions };

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,27 +1,49 @@
 import * as React from "react";
 import * as SwitchPrimitives from "@radix-ui/react-switch";
+import { motion } from "framer-motion";
 
 import { cn } from "@/lib/utils";
 
+import { useSilentMotion, type MotionIntensity } from "./silent-motion";
+
+type SwitchProps = React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root> & {
+  disableMotion?: boolean;
+  motionIntensity?: MotionIntensity;
+};
+
+const MotionSwitchRoot = motion(SwitchPrimitives.Root);
+const MotionSwitchThumb = motion(SwitchPrimitives.Thumb);
+
 const Switch = React.forwardRef<
   React.ElementRef<typeof SwitchPrimitives.Root>,
-  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
->(({ className, ...props }, ref) => (
-  <SwitchPrimitives.Root
-    className={cn(
-      "peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
-      className,
-    )}
-    {...props}
-    ref={ref}
-  >
-    <SwitchPrimitives.Thumb
+  SwitchProps
+>(({ className, disableMotion, motionIntensity = "base", ...props }, ref) => {
+  const motionProps = useSilentMotion({
+    disabled: disableMotion || props.disabled,
+    intensity: motionIntensity,
+    focus: false,
+  });
+
+  return (
+    <MotionSwitchRoot
       className={cn(
-        "pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0",
+        "peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+        className,
       )}
-    />
-  </SwitchPrimitives.Root>
-));
+      {...motionProps}
+      {...props}
+      ref={ref}
+    >
+      <MotionSwitchThumb
+        layout
+        transition={{ type: "spring", stiffness: 380, damping: 28 }}
+        className={cn(
+          "pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0",
+        )}
+      />
+    </MotionSwitchRoot>
+  );
+});
 Switch.displayName = SwitchPrimitives.Root.displayName;
 
 export { Switch };

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,6 +1,10 @@
 import * as React from "react";
 import { cva, type VariantProps } from "class-variance-authority";
+import { motion } from "framer-motion";
+
 import { cn } from "@/lib/utils";
+
+import { useSilentMotion, type MotionIntensity } from "./silent-motion";
 
 const textareaVariants = cva(
   "flex w-full px-3 py-2 text-base md:text-sm ring-offset-background placeholder:text-muted-foreground caret-[hsl(var(--ring))] disabled:cursor-not-allowed disabled:opacity-50 transition-[color,background-color,border-color,box-shadow,transform] duration-200 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 placeholder:transition-opacity placeholder:opacity-70 focus-visible:placeholder:opacity-50 selection:bg-ring/20",
@@ -51,22 +55,45 @@ const textareaVariants = cva(
 
 export interface TextareaProps
   extends React.TextareaHTMLAttributes<HTMLTextAreaElement>,
-    VariantProps<typeof textareaVariants> {}
+    VariantProps<typeof textareaVariants> {
+  disableMotion?: boolean;
+  motionIntensity?: MotionIntensity;
+}
+
+const MotionTextarea = motion.textarea;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   (
-    { className, resizable, minHeight, appearance, radius, invalid, ...props },
+    {
+      className,
+      resizable,
+      minHeight,
+      appearance,
+      radius,
+      invalid,
+      disableMotion,
+      motionIntensity = "subtle",
+      ...props
+    },
     ref,
-  ) => (
-    <textarea
-      className={cn(
-        textareaVariants({ resizable, minHeight, appearance, radius, invalid }),
-        className,
-      )}
-      ref={ref}
-      {...props}
-    />
-  ),
+  ) => {
+    const motionProps = useSilentMotion({
+      disabled: disableMotion || props.disabled,
+      intensity: motionIntensity,
+    });
+
+    return (
+      <MotionTextarea
+        className={cn(
+          textareaVariants({ resizable, minHeight, appearance, radius, invalid }),
+          className,
+        )}
+        ref={ref}
+        {...motionProps}
+        {...props}
+      />
+    );
+  },
 );
 Textarea.displayName = "Textarea";
 

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -1,8 +1,11 @@
 import * as React from "react";
 import * as TogglePrimitive from "@radix-ui/react-toggle";
 import { cva, type VariantProps } from "class-variance-authority";
+import { motion } from "framer-motion";
 
 import { cn } from "@/lib/utils";
+
+import { useSilentMotion, type MotionIntensity } from "./silent-motion";
 
 const toggleVariants = cva(
   "inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors hover:bg-muted hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 gap-2",
@@ -26,17 +29,32 @@ const toggleVariants = cva(
   },
 );
 
+type ToggleProps = React.ComponentPropsWithoutRef<typeof TogglePrimitive.Root> &
+  VariantProps<typeof toggleVariants> & {
+    disableMotion?: boolean;
+    motionIntensity?: MotionIntensity;
+  };
+
+const MotionToggleRoot = motion(TogglePrimitive.Root);
+
 const Toggle = React.forwardRef<
   React.ElementRef<typeof TogglePrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof TogglePrimitive.Root> &
-    VariantProps<typeof toggleVariants>
->(({ className, variant, size, ...props }, ref) => (
-  <TogglePrimitive.Root
-    ref={ref}
-    className={cn(toggleVariants({ variant, size, className }))}
-    {...props}
-  />
-));
+  ToggleProps
+>(({ className, variant, size, disableMotion, motionIntensity = "base", ...props }, ref) => {
+  const motionProps = useSilentMotion({
+    disabled: disableMotion || props.disabled,
+    intensity: motionIntensity,
+  });
+
+  return (
+    <MotionToggleRoot
+      ref={ref}
+      className={cn(toggleVariants({ variant, size, className }))}
+      {...motionProps}
+      {...props}
+    />
+  );
+});
 
 Toggle.displayName = TogglePrimitive.Root.displayName;
 


### PR DESCRIPTION
## Summary
- introduce a reusable `useSilentMotion` hook to standardize subtle motion states
- wrap button, card, input, textarea, toggle, and switch primitives with silent motion behavior
- allow motion to be disabled or tuned through optional component props

## Testing
- npm run build -- --logLevel warn

------
https://chatgpt.com/codex/tasks/task_e_690a42b837ac832dbb205b92022e6a1b

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces `useSilentMotion` and applies subtle framer-motion interactions to Button, Card, Input, Textarea, Toggle, and Switch with opt-out and tunable intensity.
> 
> - **Core**:
>   - `src/components/ui/silent-motion.ts`: New `useSilentMotion` hook providing hover/tap/focus motion with intensity levels and reduced-motion respect.
> - **Components**:
>   - `Button`: Wraps with `motion.button`; adds `disableMotion`; respects `disabled`/`aria-disabled`; keeps `asChild` path.
>   - `Card`: Converts to `motion.div`; adds `disableMotion` and `motionIntensity`.
>   - `Input`/`Textarea`: Convert to motion elements; add `disableMotion` and `motionIntensity`.
>   - `Toggle`: Wraps Radix root with motion; adds `disableMotion`/`motionIntensity`.
>   - `Switch`: Wraps Radix root and thumb with motion; adds `disableMotion`/`motionIntensity`, disables focus motion on root; thumb uses spring `layout` transition.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe7b70d4b720aa14e702aa9a8efc49daa41cf2fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->