### PR TITLE
Switch typography to Space Grotesk

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Nunito+Sans:wght@400;500;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&display=swap"
     />
 
     <title>Yanis Sebastian Zürcher • Software Developer in Zürich</title>

--- a/src/index.css
+++ b/src/index.css
@@ -313,7 +313,7 @@
 
   * {
     @apply border-border outline-ring/50;
-    font-family: "Nunito Sans", system-ui, sans-serif;
+    font-family: "Space Grotesk", system-ui, sans-serif;
   }
 
   code,

--- a/src/pages/AboutThisWebsite.tsx
+++ b/src/pages/AboutThisWebsite.tsx
@@ -94,11 +94,11 @@ export default function AboutThisWebsite() {
           . Typography:{" "}
           <strong>
             <LinkPreview
-              href="https://fonts.google.com/specimen/Nunito+Sans"
+              href="https://fonts.google.com/specimen/Space+Grotesk"
               className="link"
               compact
             >
-              Nunito Sans
+              Space Grotesk
             </LinkPreview>
           </strong>
           .


### PR DESCRIPTION
### Motivation
- Replace the site's current `Nunito Sans` typeface with `Space Grotesk` for a refreshed typographic voice and to reflect the updated design choice in content.

### Description
- Load `Space Grotesk` from Google Fonts by updating the `<link>` in `index.html`.
- Update the global font stack to `"Space Grotesk", system-ui, sans-serif` in `src/index.css`.
- Update the mention and Google Fonts link in `src/pages/AboutThisWebsite.tsx` from `Nunito Sans` to `Space Grotesk`.

### Testing
- Started the dev server with `npm run dev` which launched successfully and served the site on `http://localhost:4173/`.
- Ran a Playwright script to load the homepage at `http://127.0.0.1:4173/` and capture a screenshot, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970c8927624832dae3e5a5c006458bd)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates site-wide typography to `Space Grotesk`.
> 
> - Loads `Space Grotesk` from Google Fonts in `index.html`
> - Sets global `font-family` to `"Space Grotesk", system-ui, sans-serif` in `src/index.css`
> - Updates `AboutThisWebsite.tsx` to reference `Space Grotesk` and its Google Fonts link
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a9059304d87bf680e604857ac70fd23ad638839. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->