### PR TITLE
Update site font to DM Sans

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Nunito+Sans:wght@400;500;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&display=swap"
     />
 
     <title>Yanis Sebastian Zürcher • Software Developer in Zürich</title>

--- a/src/index.css
+++ b/src/index.css
@@ -313,7 +313,7 @@
 
   * {
     @apply border-border outline-ring/50;
-    font-family: "Nunito Sans", system-ui, sans-serif;
+    font-family: "DM Sans", system-ui, sans-serif;
   }
 
   code,

--- a/src/pages/AboutThisWebsite.tsx
+++ b/src/pages/AboutThisWebsite.tsx
@@ -94,11 +94,11 @@ export default function AboutThisWebsite() {
           . Typography:{" "}
           <strong>
             <LinkPreview
-              href="https://fonts.google.com/specimen/Nunito+Sans"
+              href="https://fonts.google.com/specimen/DM+Sans"
               className="link"
               compact
             >
-              Nunito Sans
+              DM Sans
             </LinkPreview>
           </strong>
           .


### PR DESCRIPTION
### Motivation
- Swap the site typography to DM Sans so the global font and documentation reference match the new design choice.

### Description
- Replace the Google Fonts import in `index.html` to load `DM Sans` instead of `Nunito Sans`.
- Update the global `font-family` in `src/index.css` to `"DM Sans", system-ui, sans-serif`.
- Update the typography link and displayed name in `src/pages/AboutThisWebsite.tsx` to reference `DM Sans`.

### Testing
- Started the local dev server with `npm run dev` and the Vite server launched successfully.
- Attempted a Playwright screenshot for verification but the headless browser crashed and the capture failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697670183eb8832daef3d91d734922a8)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches site typography to DM Sans.
> 
> - Update Google Fonts import in `index.html` to `DM Sans`
> - Set global `font-family` in `src/index.css` to `"DM Sans", system-ui, sans-serif`
> - Change typography link and label in `src/pages/AboutThisWebsite.tsx` to `DM Sans`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea44eab2dc97b969555c0e6f517172721520972c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->