### PR TITLE
Restore Geist font and add subtle motion to Switch

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Nunito+Sans:wght@400;500;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&display=swap"
     />
 
     <title>Yanis Sebastian Zürcher • Software Developer in Zürich</title>

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import * as SwitchPrimitives from "@radix-ui/react-switch";
+import { motion } from "motion/react";
 
 import { cn } from "@/lib/utils";
 
@@ -9,17 +10,22 @@ const Switch = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SwitchPrimitives.Root
     className={cn(
-      "peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+      "peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent px-0.5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:justify-end data-[state=unchecked]:justify-start data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
       className,
     )}
     {...props}
     ref={ref}
   >
-    <SwitchPrimitives.Thumb
-      className={cn(
-        "pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0",
-      )}
-    />
+    <SwitchPrimitives.Thumb asChild>
+      <motion.span
+        layout
+        transition={{ type: "spring", stiffness: 500, damping: 30 }}
+        whileTap={{ scale: 0.97 }}
+        className={cn(
+          "pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0",
+        )}
+      />
+    </SwitchPrimitives.Thumb>
   </SwitchPrimitives.Root>
 ));
 Switch.displayName = SwitchPrimitives.Root.displayName;

--- a/src/index.css
+++ b/src/index.css
@@ -313,7 +313,7 @@
 
   * {
     @apply border-border outline-ring/50;
-    font-family: "Nunito Sans", system-ui, sans-serif;
+    font-family: "Geist", system-ui, sans-serif;
   }
 
   code,

--- a/src/pages/AboutThisWebsite.tsx
+++ b/src/pages/AboutThisWebsite.tsx
@@ -94,11 +94,11 @@ export default function AboutThisWebsite() {
           . Typography:{" "}
           <strong>
             <LinkPreview
-              href="https://fonts.google.com/specimen/Nunito+Sans"
+              href="https://fonts.google.com/specimen/Geist"
               className="link"
               compact
             >
-              Nunito Sans
+              Geist
             </LinkPreview>
           </strong>
           .


### PR DESCRIPTION
### Motivation
- Restore the site typography to the `Geist` font and update the about page reference to match the chosen font. 
- Provide a subtle, more tactile animation for the shadcn `Switch` component using the `motion` library for a smoother UI interaction.

### Description
- Replaced the Google Fonts import in `index.html` to load `Geist` instead of `Nunito Sans`.
- Updated the global font-family in `src/index.css` to `"Geist", system-ui, sans-serif`.
- Updated the typography reference on the about page in `src/pages/AboutThisWebsite.tsx` to point to the `Geist` font.
- Enhanced the shadcn `Switch` component in `src/components/ui/switch.tsx` by importing `motion` from `motion/react`, adjusting root classes for proper thumb alignment (`px-0.5` and `data-[state=checked]:justify-end`), and rendering the thumb as a `motion.span` with `layout`, a spring `transition`, and a `whileTap` scale effect.

### Testing
- Ran the dev server with `npm run dev` and confirmed Vite served the app successfully.
- Executed a Playwright script to load the app and capture a screenshot of the updated switch; the script completed and produced a screenshot artifact successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b3662ee0c832db9dc12e3e4783226)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only changes: swaps the site’s font to `Geist` and tweaks the `Switch` thumb to use `motion`-based animation and alignment, with no data/auth logic affected.
> 
> **Overview**
> Restores site typography to `Geist` by switching the Google Fonts import in `index.html`, updating the global `font-family` in `src/index.css`, and correcting the About page typography link/text.
> 
> Updates the shadcn `Switch` to feel more tactile by adjusting root alignment/padding classes and rendering the thumb as a `motion` element with spring-based layout animation and a small press-scale effect.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 029c178ee468a25083a584ba9681071a28c77c53. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->